### PR TITLE
`ArchiveFont` and `ArchiveFontBase` implementations in `nw4r::ut`

### DIFF
--- a/libs/NW4R/include/nw4r/ut/ArchiveFont.h
+++ b/libs/NW4R/include/nw4r/ut/ArchiveFont.h
@@ -1,22 +1,116 @@
 #ifndef NW4R_UT_ARCHIVE_FONT_H
 #define NW4R_UT_ARCHIVE_FONT_H
 
+#include <nw4r/ut/ResFont.h>
+#include <revolution/cx.h>
 #include <revolution/types.h>
 
 namespace nw4r {
     namespace ut {
         namespace detail {
-            class ArchiveFontBase {
+            class ArchiveFontBase : public ResFontBase {
+            public:
+                ArchiveFontBase();
+                virtual ~ArchiveFontBase();
+
             protected:
-                u8 dummy[0x1c];
+                typedef enum {
+                    CONSTRUCT_STATE_DATA_REQUESTED = 0x00,
+                    CONSTRUCT_STATE_DONE = 0x01,
+                    CONSTRUCT_STATE_FATAL_ERR = 0x02,
+                    CONSTRUCT_STATE_WORKING = 0x03,
+                } ConstructState;
+
+                typedef enum {
+                    CONSTRUCT_CMD_DISPATCH = 0x00,
+                    CONSTRUCT_CMD_ANALYZE_FILE_HEADER = 0x01,
+                    CONSTRUCT_CMD_ANALYZE_GLGR = 0x02,
+                    CONSTRUCT_CMD_ANALYZE_FINF = 0x03,
+                    CONSTRUCT_CMD_ANALYZE_CMAP = 0x04,
+                    CONSTRUCT_CMD_ANALYZE_CWDH = 0x05,
+                    CONSTRUCT_CMD_ANALYZE_TGLP = 0x06,
+                    CONSTRUCT_CMD_PREPARE_COPY_SHEET = 0x07,
+                    CONSTRUCT_CMD_PREPARE_EXPAND_SHEET = 0x08,
+                    CONSTRUCT_CMD_COPY = 0x09,
+                    CONSTRUCT_CMD_SKIP = 0x0A,
+                    CONSTRUCT_CMD_EXPAND = 0x0B,
+                    CONSTRUCT_CMD_FATAL_ERR = 0x0C,
+                    CONSTRUCT_CMD_MAX_CMD = 0x0D,
+                } ConstructCmd;
+
+                class ConstructContext;
+                class CachedStreamReader {
+                public:
+                    void Init();
+                    void Attach(void* data, u32 dataLen);
+                    bool RequestData(ConstructContext& ctx, u32 len);
+
+                    u8* advanceData(u32 len);
+                    u32 amtAvailableData();
+                    u32 amtAvailableCached();
+                    u32 amtAvailable();
+                    u32 amtAvailableRevLoadOrder();
+                    void copyBugged(void* dst, u32 len);
+                    void memcpyToWork(ConstructContext& ctx, u32 len);
+                    void copyMemmove(void* dst, u32 len);
+
+                    u8* getDataCurr();
+
+                    u8* pDataStart;
+                    u8* pDataCurr;
+                    u8* pDataEnd;
+                    u8* pCachedBase;
+                    u8* pCachedStart;
+                    u8* pCachedEnd;
+                    u32 unk_0x18;
+                };
+                class ConstructContext {
+                public:
+                    u32 remWorkSpace();
+                    void updateDataOffset(CachedStreamReader& reader);
+                    ConstructState requestNewData(CachedStreamReader& reader, u32 amt);
+                    FontInformation* pFinf;
+                    u32 unk_0x004;
+                    FontCodeMap* pMostRecentCMAP;
+                    u32 mNextCmd;
+                    u32 mNextBlockSig;
+                    u32 mNextBlockLen;
+                    u32 mDataOffset;
+                    CachedStreamReader mReader;
+                    CXUncompContextHuffman* pHuffmanCtx;
+                    char* pIncludedSubfonts;
+                    u16* pSheetOffsets;
+                    u8* pWorkStart;
+                    u8* pWorkEnd;
+                    u8* pWorkCurr;
+                    u32 mQueuedCmd;
+                    u32 mNextCmdParam;
+                    u32 mTotalBlocks;
+                    u32 mBlocksParsed;
+                    u16 mSheetsHandled;
+                    u16 mSheetCount;
+                    u16 mGlyphsPerSheet;
+                };
+
+                static ConstructState ConstructOpAnalyzeFileHeader(ConstructContext& ctx, CachedStreamReader& reader);
+                static ConstructState ConstructOpAnalyzeFINF(ConstructContext& ctx);
+                static ConstructState ConstructOpCopy(ConstructContext& ctx, CachedStreamReader& reader);
+                static ConstructState ConstructOpSkip(ConstructContext& ctx, CachedStreamReader& reader);
+                static ConstructState ConstructOpExpand(ConstructContext& ctx, CachedStreamReader& reader);
+                static ConstructState ConstructOpFatalErr(ConstructContext& ctx);
+
+                u16* pSheetOffsets;
 
                 static const char LOAD_GLYPH_ALL[1];
+
+            private:
             };
         };  // namespace detail
 
         class ArchiveFont : public detail::ArchiveFontBase {
         public:
             ArchiveFont();
+            virtual ~ArchiveFont();
 
             static u32 GetRequireBufferSize(const void* param_1, const char* param_2 = LOAD_GLYPH_ALL);
 

--- a/libs/NW4R/include/nw4r/ut/ArchiveFont.h
+++ b/libs/NW4R/include/nw4r/ut/ArchiveFont.h
@@ -1,6 +1,7 @@
 #ifndef NW4R_UT_ARCHIVE_FONT_H
 #define NW4R_UT_ARCHIVE_FONT_H
 
+#include <nw4r/config.h>
 #include <nw4r/ut/ResFont.h>
 #include <revolution/cx.h>
 #include <revolution/types.h>
@@ -8,12 +9,51 @@
 namespace nw4r {
     namespace ut {
         namespace detail {
+            inline u32 CalcOffsetNameOffsetData() {
+                return offsetof(ArchiveFontBinaryLayout, glgr.inner.nameOffsets);
+            }
+
+            inline u32 CalcOffsetSheetData(u16 countNames) {
+                return ROUNDUP(CalcOffsetNameOffsetData() + countNames * sizeof(u16), 4);
+            }
+            inline u32 CalcOffset0AData(u16 countNames, u16 countSheets) {
+                return ROUNDUP(CalcOffsetSheetData(countNames) + countSheets * sizeof(u32), 4);
+            }
+            inline u32 CalcOffset0CData(u16 countNames, u16 countSheets, u16 count0A) {
+                return ROUNDUP(CalcOffset0AData(countNames, countSheets) + count0A * sizeof(u32), 4);
+            }
+
+            inline u32 CalcOffsetSheetFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
+                return ROUNDUP(CalcOffset0CData(countNames, countSheets, count0A) + count0C * sizeof(u32), 4);
+            }
+            inline u32 CalcSizeSheetFlagSet(u32 countSheets) {
+                return ((s32)countSheets + 0x1f) / 32 * 4;
+            }
+
+            inline u32 CalcOffset0AFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
+                return ROUNDUP(CalcOffsetSheetFlags(countNames, countSheets, count0A, count0C) + countNames * CalcSizeSheetFlagSet(countSheets), 4);
+            }
+            inline u32 CalcSize0AFlagSet(u32 count0A) {
+                return ((s32)count0A + 0x1f) / 32 * 4;
+            }
+
+            inline u32 CalcOffset0CFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
+                return ROUNDUP(CalcOffsetSheetFlags(countNames, countSheets, count0A, count0C) + countNames * CalcSize0AFlagSet(count0A), 4);
+            }
+            inline u32 CalcSize0CFlagSet(u32 count0C) {
+                return ((s32)count0C + 0x1f) / 32 * 4;
+            }
+
+            inline u32 CalcSizeSheetOffsets(u32 countSheets) {
+                return ROUNDUP(countSheets * sizeof(u16), 4);
+            }
+
             class ArchiveFontBase : public ResFontBase {
             public:
                 ArchiveFontBase();
                 virtual ~ArchiveFontBase();
 
-            protected:
+                // protected:
                 typedef enum {
                     CONSTRUCT_STATE_DATA_REQUESTED = 0x00,
                     CONSTRUCT_STATE_DONE = 0x01,
@@ -29,81 +69,140 @@ namespace nw4r {
                     CONSTRUCT_CMD_ANALYZE_CMAP = 0x04,
                     CONSTRUCT_CMD_ANALYZE_CWDH = 0x05,
                     CONSTRUCT_CMD_ANALYZE_TGLP = 0x06,
-                    CONSTRUCT_CMD_PREPARE_COPY_SHEET = 0x07,
-                    CONSTRUCT_CMD_PREPARE_EXPAND_SHEET = 0x08,
+                    CONSTRUCT_CMD_PREPAIR_COPY_SHEET = 0x07,
+                    CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET = 0x08,
                     CONSTRUCT_CMD_COPY = 0x09,
                     CONSTRUCT_CMD_SKIP = 0x0A,
                     CONSTRUCT_CMD_EXPAND = 0x0B,
                     CONSTRUCT_CMD_FATAL_ERR = 0x0C,
+
                     CONSTRUCT_CMD_MAX_CMD = 0x0D,
+                    CONSTRUCT_CMD_INVALID = 0x0E,
                 } ConstructCmd;
 
                 class ConstructContext;
                 class CachedStreamReader {
                 public:
                     void Init();
-                    void Attach(void* data, u32 dataLen);
-                    bool RequestData(ConstructContext& ctx, u32 len);
+                    void Attach(const void* data, u32 dataLen);
+                    bool RequestData(ConstructContext* ctx, u32 len);
 
-                    u8* advanceData(u32 len);
-                    u32 amtAvailableData();
-                    u32 amtAvailableCached();
-                    u32 amtAvailable();
-                    u32 amtAvailableRevLoadOrder();
-                    void copyBugged(void* dst, u32 len);
-                    void memcpyToWork(ConstructContext& ctx, u32 len);
-                    void copyMemmove(void* dst, u32 len);
+                    inline u32 amtAvailableData() { return pDataEnd - pDataCurr; }
+                    inline u32 amtAvailableCached() { return pCachedEnd - pCachedStart; }
+                    inline u32 amtAvailable() { return amtAvailableData() + amtAvailableCached(); }
+                    inline u32 amtAvailableRevLoadOrder();  // Fakematch enabler :(
 
-                    u8* getDataCurr();
+                    inline void memcpyToBuf(void* buf, u32 len);
+                    inline void memcpyToBufRev(void* buf, u32 len);       // Probably a fakematch enabler :(
+                    inline void memcpyToBufReaccess(void* buf, u32 len);  // Fakematch enabler :(
+                    inline void skipReaccess(u32 len);                    // Fakematch enabler :(
 
-                    u8* pDataStart;
-                    u8* pDataCurr;
-                    u8* pDataEnd;
-                    u8* pCachedBase;
-                    u8* pCachedStart;
-                    u8* pCachedEnd;
-                    u32 unk_0x18;
+                    inline u32 getCurrentOffset();
+
+                    u8* pDataStart;    // 0x00
+                    u8* pDataCurr;     // 0x04
+                    u8* pDataEnd;      // 0x08
+                    u8* pCachedBase;   // 0x0C
+                    u8* pCachedStart;  // 0x10
+                    u8* pCachedEnd;    // 0x14
+                    u32 unk_0x18;      // 0x18
                 };
                 class ConstructContext {
                 public:
-                    u32 remWorkSpace();
-                    void updateDataOffset(CachedStreamReader& reader);
-                    ConstructState requestNewData(CachedStreamReader& reader, u32 amt);
-                    FontInformation* pFinf;
-                    u32 unk_0x004;
-                    FontCodeMap* pMostRecentCMAP;
-                    u32 mNextCmd;
-                    u32 mNextBlockSig;
-                    u32 mNextBlockLen;
-                    u32 mDataOffset;
-                    CachedStreamReader mReader;
-                    CXUncompContextHuffman* pHuffmanCtx;
-                    char* pIncludedSubfonts;
-                    u16* pSheetOffsets;
-                    u8* pWorkStart;
-                    u8* pWorkEnd;
-                    u8* pWorkCurr;
-                    u32 mQueuedCmd;
-                    u32 mNextCmdParam;
-                    u32 mTotalBlocks;
-                    u32 mBlocksParsed;
-                    u16 mSheetsHandled;
-                    u16 mSheetCount;
-                    u16 mGlyphsPerSheet;
+                    inline void getNumSheetsToLoad(u16* sheetsToLoad) const;
+                    inline u32 remWorkSpace() const;
+
+                    inline void updateDataOffset(CachedStreamReader* reader);
+                    inline ConstructState requestNewData(CachedStreamReader* reader, u32 amt);
+                    inline u16 updateTextureBlockFormat();
+                    inline u32 updateTextureBlockPtr();
+
+                    inline void enqueueCmds(ConstructCmd first, u32 firstParam, ConstructCmd after) {
+                        mNextCmdParam = firstParam;
+                        mNextCmd = first;
+                        mQueuedCmd = after;
+                    }
+
+                    inline void pushCWDH() {
+                        FontWidth* cwdh;
+                        cwdh = (FontWidth*)pWorkCurr;
+                        if (pLastWidth != NULL)
+                            pLastWidth->pNext = cwdh;
+                        else
+                            pFontInfo->pWidth = cwdh;
+
+                        pLastWidth = cwdh;
+                    }
+                    inline void pushCMAP() {
+                        FontCodeMap* cmap;
+                        cmap = (FontCodeMap*)pWorkCurr;
+                        if (pLastMap != NULL)
+                            pLastMap->pNext = cmap;
+                        else
+                            pFontInfo->pMap = cmap;
+
+                        pLastMap = cmap;
+                    }
+
+                    FontInformation* pFontInfo;           // 0x00
+                    FontWidth* pLastWidth;                // 0x04
+                    FontCodeMap* pLastMap;                // 0x08
+                    u32 mNextCmd;                         // 0x0C
+                    BinaryBlockHeader mNextBlockHdr;      // 0x10
+                    u32 mDataOffset;                      // 0x18
+                    CachedStreamReader mReader;           // 0x1C
+                    CXUncompContextHuffman* pHuffmanCtx;  // 0x38
+                    const char* pIncludedGroups;          // 0x3C
+                    u16* pSheetOffsets;                   // 0x40
+                    u8* pWorkStart;                       // 0x44
+                    u8* pWorkEnd;                         // 0x48
+                    u8* pWorkCurr;                        // 0x4C
+                    u32 mQueuedCmd;                       // 0x50
+                    u32 mNextCmdParam;                    // 0x54
+                    u32 mTotalBlocks;                     // 0x58
+                    u32 mBlocksParsed;                    // 0x5C
+                    u16 mSheetsHandled;                   // 0x60
+                    u16 mSheetCount;                      // 0x62
+                    u16 mGlyphsPerSheet;                  // 0x64
                 };
 
-                static ConstructState ConstructOpAnalyzeFileHeader(ConstructContext& ctx, CachedStreamReader& reader);
-                static ConstructState ConstructOpAnalyzeFINF(ConstructContext& ctx);
-                static ConstructState ConstructOpCopy(ConstructContext& ctx, CachedStreamReader& reader);
-                static ConstructState ConstructOpSkip(ConstructContext& ctx, CachedStreamReader& reader);
-                static ConstructState ConstructOpExpand(ConstructContext& ctx, CachedStreamReader& reader);
-                static ConstructState ConstructOpFatalErr(ConstructContext& ctx);
+                static bool IsValidResource(const void* data, u32 maxPreFinfSize);
+                CharWidths GetCharWidths(u16 charcode) const;
+                void SetResourceBuffer(void* pUserBuffer, FontInformation* pFontInfo, u16* pSheetOffsets);
+                u16 AdjustIndex(u16 glyphIdx) const;
+                static bool IncludeName(const char* nameList, const char* testName);
 
-                u16* pSheetOffsets;
+            protected:
+                static ConstructState ConstructOpDispatch(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeFileHeader(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeGLGR(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeFINF(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeTGLP(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeCMAP(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpAnalyzeCWDH(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpPrepairCopySheet(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpPrepairExpandSheet(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpCopy(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpSkip(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpExpand(ConstructContext* ctx, CachedStreamReader* reader);
+                static ConstructState ConstructOpFatalError(ConstructContext* ctx, CachedStreamReader* reader);
 
                 static const char LOAD_GLYPH_ALL[1];
 
             private:
+                inline static ConstructState handleAdvanceDry(ConstructContext* ctx, CachedStreamReader* reader, u32 advanced);
+
+                u16* pSheetOffsets;  // 0x18
+
+                static const u16 VERSION = NW4R_VERSION(1, 4);
+                static const u32 SIGNATURE_FONT_ARCHIVE = 'RFNA';
+
+                static const u32 SIGNATURE_FONT_INFO = 'FINF';  /* Font INFormation */
+                static const u32 SIGNATURE_TEX_GLYPH = 'TGLP';  /* Texture GLyPh */
+                static const u32 SIGNATURE_CHAR_WIDTH = 'CWDH'; /* Character WiDtH */
+                static const u32 SIGNATURE_CODE_MAP = 'CMAP';   /* Code MAP */
+
+                static const u32 SIGNATURE_GLYPH_GROUPS = 'GLGR'; /* GLyph GRoups */
             };
         };  // namespace detail
 

--- a/libs/NW4R/include/nw4r/ut/ArchiveFont.h
+++ b/libs/NW4R/include/nw4r/ut/ArchiveFont.h
@@ -211,9 +211,15 @@ namespace nw4r {
             ArchiveFont();
             virtual ~ArchiveFont();
 
-            static u32 GetRequireBufferSize(const void* param_1, const char* param_2 = LOAD_GLYPH_ALL);
+            static u32 GetRequireBufferSize(const void* fontData, const char* includedGroups = LOAD_GLYPH_ALL);
 
-            bool Construct(void* param_1, u32 param_2, const void* param_3, const char* param_4 = LOAD_GLYPH_ALL);
+            virtual void GetGlyph(Glyph* glyph, u16 c) const;
+            void GetGlyphFromRealIndex(FontTextureGlyph& tg, Glyph* glyph, u16 index, u16 realIndex) const;
+            void GetGlyphFromIndex(Glyph* glyph, u16 index) const;
+
+            detail::ArchiveFontBase::ConstructState StreamingConstruct(ArchiveFontBase::ConstructContext* ctx, const void* fontData,
+                                                                       u32 fontDataSize);
+            bool Construct(void* work, u32 workSize, const void* fontData, const char* includedGroups = LOAD_GLYPH_ALL);
         };
     }  // namespace ut
 }  // namespace nw4r

--- a/libs/NW4R/include/nw4r/ut/ArchiveFont.h
+++ b/libs/NW4R/include/nw4r/ut/ArchiveFont.h
@@ -84,17 +84,14 @@ namespace nw4r {
                     void Attach(const void* data, u32 dataLen);
                     bool RequestData(ConstructContext* ctx, u32 len);
 
-                    inline u8* advanceData(u32 amt) { return (pDataCurr += amt) - amt; }
-
                     inline u32 amtAvailableData() const { return pDataEnd - pDataCurr; }
                     inline u32 amtAvailableCached() const { return pCachedEnd - pCachedStart; }
                     inline u32 amtAvailable() const { return amtAvailableData() + amtAvailableCached(); }
 
-                    inline void memcpyToBuf(void* buf, u32 len);
-                    inline void memcpyToBufRev(void* buf, u32 len);  // Probably a fakematch enabler :(
-                    inline void skipReaccess(u32 len);               // Fakematch enabler :(
+                    inline u32 getReaderOffset() const { return (pDataCurr - pDataStart) + (pCachedStart - pCachedBase); }
 
-                    inline u32 getCurrentOffset();
+                    inline void memcpyToBuf(void* buf, u32 len);
+                    inline void skip(u32 len);
 
                     u8* pDataStart;    // 0x00
                     u8* pDataCurr;     // 0x04
@@ -106,12 +103,13 @@ namespace nw4r {
                 };
                 class ConstructContext {
                 public:
-                    inline void getNumSheetsToLoad(u16* sheetsToLoad) const;
-                    inline u32 remWorkSpace() const;
+                    inline u32 getAdvanceSize(const CachedStreamReader* reader) const { return ut::Min(mNextCmdParam, reader->amtAvailable()); }
+                    inline u32 remWorkSpace() const { return pWorkEnd - pWorkCurr; }
 
-                    inline void updateDataOffset(CachedStreamReader* reader);
+                    inline u32 getFullOffset(CachedStreamReader* reader) const { return mDataOffset + reader->getReaderOffset(); }
                     inline ConstructState requestNewData(CachedStreamReader* reader, u32 amt);
-                    inline u16 updateTextureBlockFormat();
+
+                    inline void getNumSheetsToLoad(u16* sheetsToLoad) const;
                     inline u32 updateTextureBlockPtr();
 
                     inline void enqueueCmds(ConstructCmd first, u32 firstParam, ConstructCmd after) {

--- a/libs/NW4R/include/nw4r/ut/ArchiveFont.h
+++ b/libs/NW4R/include/nw4r/ut/ArchiveFont.h
@@ -23,25 +23,22 @@ namespace nw4r {
                 return ROUNDUP(CalcOffset0AData(countNames, countSheets) + count0A * sizeof(u32), 4);
             }
 
+            inline u32 CalcSizeFlagSet(u32 entries) {
+                return ((s32)entries + 0x1f) / 32 * 4;
+            }
+
             inline u32 CalcOffsetSheetFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
                 return ROUNDUP(CalcOffset0CData(countNames, countSheets, count0A) + count0C * sizeof(u32), 4);
             }
-            inline u32 CalcSizeSheetFlagSet(u32 countSheets) {
-                return ((s32)countSheets + 0x1f) / 32 * 4;
-            }
-
             inline u32 CalcOffset0AFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
-                return ROUNDUP(CalcOffsetSheetFlags(countNames, countSheets, count0A, count0C) + countNames * CalcSizeSheetFlagSet(countSheets), 4);
+                u32 offsetSheetFlags = CalcOffsetSheetFlags(countNames, countSheets, count0A, count0C);
+                u32 stepSheet = CalcSizeFlagSet(countSheets);
+                return ROUNDUP(offsetSheetFlags + stepSheet * countNames, 4);
             }
-            inline u32 CalcSize0AFlagSet(u32 count0A) {
-                return ((s32)count0A + 0x1f) / 32 * 4;
-            }
-
             inline u32 CalcOffset0CFlags(u16 countNames, u16 countSheets, u16 count0A, u16 count0C) {
-                return ROUNDUP(CalcOffsetSheetFlags(countNames, countSheets, count0A, count0C) + countNames * CalcSize0AFlagSet(count0A), 4);
-            }
-            inline u32 CalcSize0CFlagSet(u32 count0C) {
-                return ((s32)count0C + 0x1f) / 32 * 4;
+                u32 offset0AFlags = CalcOffset0AFlags(countNames, countSheets, count0A, count0C);
+                u32 step0A = CalcSizeFlagSet(count0A);
+                return ROUNDUP(offset0AFlags + step0A * countNames, 4);
             }
 
             inline u32 CalcSizeSheetOffsets(u32 countSheets) {
@@ -87,15 +84,15 @@ namespace nw4r {
                     void Attach(const void* data, u32 dataLen);
                     bool RequestData(ConstructContext* ctx, u32 len);
 
-                    inline u32 amtAvailableData() { return pDataEnd - pDataCurr; }
-                    inline u32 amtAvailableCached() { return pCachedEnd - pCachedStart; }
-                    inline u32 amtAvailable() { return amtAvailableData() + amtAvailableCached(); }
-                    inline u32 amtAvailableRevLoadOrder();  // Fakematch enabler :(
+                    inline u8* advanceData(u32 amt) { return (pDataCurr += amt) - amt; }
+
+                    inline u32 amtAvailableData() const { return pDataEnd - pDataCurr; }
+                    inline u32 amtAvailableCached() const { return pCachedEnd - pCachedStart; }
+                    inline u32 amtAvailable() const { return amtAvailableData() + amtAvailableCached(); }
 
                     inline void memcpyToBuf(void* buf, u32 len);
-                    inline void memcpyToBufRev(void* buf, u32 len);       // Probably a fakematch enabler :(
-                    inline void memcpyToBufReaccess(void* buf, u32 len);  // Fakematch enabler :(
-                    inline void skipReaccess(u32 len);                    // Fakematch enabler :(
+                    inline void memcpyToBufRev(void* buf, u32 len);  // Probably a fakematch enabler :(
+                    inline void skipReaccess(u32 len);               // Fakematch enabler :(
 
                     inline u32 getCurrentOffset();
 

--- a/libs/NW4R/include/nw4r/ut/ResFont.h
+++ b/libs/NW4R/include/nw4r/ut/ResFont.h
@@ -58,7 +58,7 @@ namespace nw4r {
 
                 bool IsManaging(const void* ptr) const { return mResource == ptr; }
 
-            private:
+            protected:
                 void* mResource;             // 0x10
                 FontInformation* mFontInfo;  // 0x14
             };

--- a/libs/NW4R/include/nw4r/ut/fontResources.h
+++ b/libs/NW4R/include/nw4r/ut/fontResources.h
@@ -5,6 +5,8 @@
 
 #include <revolution/gx/GXEnum.h>
 
+#include <nw4r/ut/binaryFileFormat.h>
+
 namespace nw4r {
     namespace ut {
         typedef struct CharWidths {
@@ -84,6 +86,24 @@ namespace nw4r {
             u8 ascent;       // 0x16
             u8 padding_[1];  // 0x17
         } FontInformation;
+        typedef struct GlyphGroups {
+            u32 uncompSheetSize;  // 0x00
+            u16 sheetGlyphCount;  // 0x04
+            u16 nameCount;        // 0x06
+            u16 sheetCount;       // 0x08
+            u16 smthCount_0x0a;   // 0x0A
+            u16 smthCount_0x0c;   // 0x0C
+            u16 nameOffsets[0];
+        } GlyphGroups;
+
+        typedef struct HeaderedGlyphGroups {
+            BinaryBlockHeader hdr;  // 0x00
+            GlyphGroups inner;      // 0x08
+        } HeaderedGlyphGroups;
+        typedef struct ArchiveFontBinaryLayout {
+            BinaryFileHeader hdr;      // 0x00
+            HeaderedGlyphGroups glgr;  // 0x10
+        } ArchiveFontBinaryLayout;
     }  // namespace ut
 }  // namespace nw4r
 

--- a/libs/NW4R/src/ut/ut_ArchiveFont.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFont.cpp
@@ -1,0 +1,318 @@
+#include <nw4r/ut/ArchiveFont.h>
+#include <nw4r/ut/Font.h>
+#include <nw4r/ut/fontResources.h>
+
+#include <nw4r/math/arithmetic.h>
+
+#include <revolution/os.h>
+
+#include <string.h>
+
+namespace nw4r {
+    namespace ut {
+#define GLYPH_INDEX_NOT_FOUND 0xFFFF
+        ArchiveFont::ArchiveFont() {
+        }
+        ArchiveFont::~ArchiveFont() {
+        }
+
+        u32 ArchiveFont::GetRequireBufferSize(const void* fontData, const char* includedGroups) {
+            if (!ArchiveFontBase::IsValidResource(fontData, 0x4000))
+                return 0;
+
+            const ArchiveFontBinaryLayout* font;
+            const HeaderedGlyphGroups* pGlgr;
+
+            u16 countName, countSheet, count0A, count0C;
+
+            u32 stepSheets;
+            u32 step0A;
+            u32 step0C;
+
+            u32 dataSheetsOff;
+            u32 data0AOff;
+            u32 data0COff;
+            const u32* dataSheets;
+            const u32* data0A;
+            const u32* data0C;
+
+            u32 flagsSheetsOff;
+            u32 flags0AOff;
+            u32 flags0COff;
+            const u32* flagsSheets;
+            const u32* flags0A;
+            const u32* flags0C;
+
+            u32 loadedSheetCount;
+            u32 loadedSmth0ASize;
+            u32 loadedSmth0CSize;
+
+            int wordI;
+            u32 flagWord;
+            const u8* offsetFlags;
+            int j;
+
+            font = (ArchiveFontBinaryLayout*)fontData;
+            pGlgr = &font->glgr;
+
+            countName = font->glgr.inner.nameCount;
+            countSheet = font->glgr.inner.sheetCount;
+            count0A = font->glgr.inner.smthCount_0x0a;
+            count0C = font->glgr.inner.smthCount_0x0c;
+
+            stepSheets = ((s32)countSheet + 0x1f) / 32 * 4;
+            step0A = ((s32)count0A + 0x1f) / 32 * 4;
+            step0C = ((s32)count0C + 0x1f) / 32 * 4;
+
+            dataSheetsOff = ROUNDUP(offsetof(ArchiveFontBinaryLayout, glgr.inner.nameOffsets) + countName * sizeof(u16), 4);
+            data0AOff = ROUNDUP(dataSheetsOff + countSheet * sizeof(u32), 4);
+            data0COff = ROUNDUP(data0AOff + count0A * sizeof(u32), 4);
+
+            flagsSheetsOff = ROUNDUP(data0COff + count0C * sizeof(u32), 4);
+            flags0AOff = ROUNDUP(flagsSheetsOff + stepSheets * countName, 4);
+            flags0COff = ROUNDUP(flags0AOff + step0A * countName, 4);
+
+            dataSheets = (const u32*)fontData + (dataSheetsOff >> 2);
+            data0A = (const u32*)fontData + (data0AOff >> 2);
+            data0C = (const u32*)fontData + (data0COff >> 2);
+
+            flagsSheets = (const u32*)fontData + (flagsSheetsOff >> 2);
+            flags0A = (const u32*)fontData + (flags0AOff >> 2);
+            flags0C = (const u32*)fontData + (flags0COff >> 2);
+
+            loadedSheetCount = 0;
+            loadedSmth0ASize = 0;
+            loadedSmth0CSize = 0;
+
+            // Get the NUMBER of sheets that should be loaded
+            for (wordI = 0; wordI * 32 < pGlgr->inner.sheetCount; wordI += 1) {
+                offsetFlags = (const u8*)flagsSheets + wordI * sizeof(u32);
+
+                flagWord = 0;
+                for (j = 0; j < pGlgr->inner.nameCount; j++) {
+                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                    if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
+                        flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * stepSheets, 4));
+                    }
+                }
+                // u32 flagsSheet = getFlagsForWord(pGlgr, (const u32*)offsetFlags, stepSheets, fontData, includedGroups);
+
+                loadedSheetCount += math::CntBit1(flagWord);
+            }
+            // getLoadedSheetCount(pGlgr, flagsSheets, stepSheets, fontData, includedGroups, &loadedSheetCount);
+
+            // Get the SIZE of unk_0x0a that should be loaded
+            for (wordI = 0; wordI * 32 < pGlgr->inner.smthCount_0x0a; wordI += 1) {
+                offsetFlags = (const u8*)flags0A + wordI * sizeof(u32);
+
+                flagWord = 0;
+                for (j = 0; j < pGlgr->inner.nameCount; j++) {
+                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                    if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
+                        flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * step0A, 4));
+                    }
+                }
+
+                const u32* offsetData = (const u32*)data0A + wordI * 32;
+                for (j = 0; j < 32; j++) {
+                    if ((flagWord << j) & 0x80000000U)
+                        loadedSmth0ASize += offsetData[j] - sizeof(BinaryBlockHeader);
+                }
+            }
+            // getLoadedSmth0ASize(pGlgr, flags0A, data0A, step0A, fontData, includedGroups, &loadedSmth0ASize);
+
+            // Get the SIZE of unk_0x0c that should be loaded
+            for (wordI = 0; wordI * 32 < pGlgr->inner.smthCount_0x0c; wordI += 1) {
+                offsetFlags = (const u8*)flags0C + wordI * sizeof(u32);
+
+                flagWord = 0;
+                for (j = 0; j < pGlgr->inner.nameCount; j++) {
+                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                    if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
+                        flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * step0C, 4));
+                    }
+                }
+
+                const u32* offsetData = (const u32*)data0C + wordI * 32;
+                for (j = 0; j < 32; j++) {
+                    if ((flagWord << j) & 0x80000000U)
+                        loadedSmth0CSize += offsetData[j] - sizeof(BinaryBlockHeader);
+                }
+            }
+            // getLoadedSmth0CSize(pGlgr, flags0C, data0C, step0C, fontData, includedGroups, &loadedSmth0CSize);
+
+            // Calculate the final buffer size based on the three previously
+            // accessed components
+            u32 sheetOffsetsSize;
+            u32 loadedSheetsSize;
+            u32 neededCharacterSize;
+            u32 baseSize;
+
+            loadedSheetsSize = ROUNDUP(loadedSheetCount * pGlgr->inner.uncompSheetSize, 4);
+            sheetOffsetsSize = ROUNDUP(pGlgr->inner.sheetCount * 2, 4);
+
+            neededCharacterSize = sizeof(CXUncompContextHuffman);
+            if (loadedSmth0ASize + loadedSmth0CSize >= sizeof(CXUncompContextHuffman))
+                neededCharacterSize = loadedSmth0ASize + loadedSmth0CSize;
+
+            baseSize = ROUNDUP(sizeof(FontInformation) + sizeof(FontTextureGlyph) + sheetOffsetsSize, 0x20);
+            return baseSize + neededCharacterSize + loadedSheetsSize;
+
+            // return totalBufferSize(pGlgr, loadedSheetCount, loadedSmth0ASize, loadedSmth0CSize);
+        }
+
+        detail::ArchiveFontBase::ConstructState ArchiveFont::StreamingConstruct(ConstructContext* ctx, const void* fontData, u32 fontDataSize) {
+            ConstructState state;
+            CachedStreamReader* reader;
+
+            // If there's already data bound, exit early
+            if (mFontInfo != NULL)
+                return ctx->mBlocksParsed < ctx->mTotalBlocks ? CONSTRUCT_STATE_FATAL_ERR : CONSTRUCT_STATE_DONE;
+
+            state = CONSTRUCT_STATE_WORKING;
+            reader = &ctx->mReader;
+            reader->Attach(fontData, fontDataSize);
+
+            while (state == CONSTRUCT_STATE_WORKING) {
+                switch (ctx->mNextCmd) {
+                    case CONSTRUCT_CMD_DISPATCH:
+                        state = detail::ArchiveFontBase::ConstructOpDispatch(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_FILE_HEADER:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeFileHeader(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_GLGR:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeGLGR(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_FINF:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeFINF(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_CMAP:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeCMAP(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_CWDH:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeCWDH(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_ANALYZE_TGLP:
+                        state = detail::ArchiveFontBase::ConstructOpAnalyzeTGLP(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_PREPAIR_COPY_SHEET:
+                        state = detail::ArchiveFontBase::ConstructOpPrepairCopySheet(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET:
+                        state = detail::ArchiveFontBase::ConstructOpPrepairExpandSheet(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_COPY:
+                        state = detail::ArchiveFontBase::ConstructOpCopy(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_SKIP:
+                        state = detail::ArchiveFontBase::ConstructOpSkip(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_EXPAND:
+                        state = detail::ArchiveFontBase::ConstructOpExpand(ctx, reader);
+                        break;
+                    case CONSTRUCT_CMD_FATAL_ERR:
+                        state = detail::ArchiveFontBase::ConstructOpFatalError(ctx, reader);
+                        break;
+                    default:
+                        ctx->mNextCmd = CONSTRUCT_CMD_FATAL_ERR;
+                        state = CONSTRUCT_STATE_FATAL_ERR;
+                }
+            }
+
+            // If everything went well, bind the work data to the resource
+            // buffer, adjust the alternate character index to respect unloaded
+            // sheets, and set the reader function (for displaying strings) to
+            // use the encoding in mFontInfo
+            if ((state == CONSTRUCT_STATE_DONE) && (mFontInfo == NULL)) {
+                DCFlushRange(ctx->pWorkStart, ctx->pWorkEnd - ctx->pWorkStart);
+                SetResourceBuffer(ctx->pWorkStart, ctx->pFontInfo, ctx->pSheetOffsets);
+                if (AdjustIndex(this->mFontInfo->alterCharIndex) == GLYPH_INDEX_NOT_FOUND) {
+                    this->mFontInfo->alterCharIndex = 0;
+                }
+                Font::InitReaderFunc(GetEncoding());
+            }
+            return state;
+        }
+
+        bool ArchiveFont::Construct(void* work, u32 workSize, const void* fontData, const char* includedGroups) {
+            u32 fontDataSize = ((BinaryFileHeader*)fontData)->fileSize;
+
+            detail::ArchiveFontBase::ConstructContext ctx;
+            ctx.mReader.Init();
+
+            // Set up data outlining which groups should be loaded and how they
+            // should be used
+            ctx.pIncludedGroups = includedGroups;
+            ctx.pSheetOffsets = NULL;
+
+            // Set up work pointers
+            ctx.pWorkStart = (u8*)work;
+            ctx.pWorkEnd = ctx.pWorkStart + workSize;
+            ctx.pWorkCurr = ctx.pWorkStart;
+
+            // Setup huffman context at the end of the work buffer
+            ctx.pHuffmanCtx = (CXUncompContextHuffman*)ROUNDDOWN((u32)(ctx.pWorkEnd - sizeof(CXUncompContextHuffman)), 4);
+
+            // Queued command params (set up only by other commands, and won't
+            // be relevant otherwise)
+            ctx.mQueuedCmd = CONSTRUCT_CMD_INVALID;
+            ctx.mNextCmdParam = 0;
+
+            ctx.mTotalBlocks = 1;
+            ctx.mBlocksParsed = 0;
+
+            // Clear sheet expansion/copy variables
+            ctx.mSheetsHandled = 0;
+            ctx.mSheetCount = 0;
+            ctx.mGlyphsPerSheet = 0;
+
+            // Clear pointers
+            ctx.mDataOffset = 0;
+            ctx.pFontInfo = NULL;
+            ctx.pLastWidth = NULL;
+            ctx.pLastMap = NULL;
+
+            // Clear other stuff???
+            ctx.mNextCmd = CONSTRUCT_CMD_ANALYZE_FILE_HEADER;
+
+            return StreamingConstruct(&ctx, fontData, fontDataSize) == CONSTRUCT_STATE_DONE;
+        }
+
+        void ArchiveFont::GetGlyph(Glyph* glyph, u16 c) const {
+            u16 idx = ResFontBase::GetGlyphIndex(c);
+            GetGlyphFromIndex(glyph, idx);
+        }
+        void ArchiveFont::GetGlyphFromIndex(Glyph* glyph, u16 index) const {
+            FontTextureGlyph& tg = *mFontInfo->pGlyph;
+
+            u16 realIndex = ArchiveFontBase::AdjustIndex(index);
+            if (realIndex == GLYPH_INDEX_NOT_FOUND) {
+                index = mFontInfo->alterCharIndex;
+                realIndex = ArchiveFontBase::AdjustIndex(index);
+            }
+
+            u32 cellsInASheet = tg.sheetRow * tg.sheetLine;
+            u32 sheetNo = realIndex / cellsInASheet;
+
+            u32 cellNo = realIndex % cellsInASheet;
+            u32 cellUnitX = cellNo % tg.sheetRow;
+            u32 cellUnitY = cellNo / tg.sheetRow;
+            u32 cellPixelX = cellUnitX * (tg.cellWidth + 1);
+            u32 cellPixelY = cellUnitY * (tg.cellHeight + 1);
+
+            u32 offsetBytes = sheetNo * tg.sheetSize;
+
+            void* pSheet = tg.sheetImage + offsetBytes;
+
+            glyph->pTexture = pSheet;
+            glyph->widths = GetCharWidthsFromIndex(index);
+            glyph->height = static_cast<u8>(tg.cellHeight);
+            glyph->texFormat = static_cast<GXTexFmt>(tg.sheetFormat);
+            glyph->texWidth = static_cast<u16>(tg.sheetWidth);
+            glyph->texHeight = static_cast<u16>(tg.sheetHeight);
+            glyph->cellX = cellPixelX + 1;
+            glyph->cellY = cellPixelY + 1;
+        }
+    }  // namespace ut
+}  // namespace nw4r

--- a/libs/NW4R/src/ut/ut_ArchiveFont.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFont.cpp
@@ -17,40 +17,39 @@ namespace nw4r {
         }
 
         u32 ArchiveFont::GetRequireBufferSize(const void* fontData, const char* includedGroups) {
-            if (!ArchiveFontBase::IsValidResource(fontData, 0x4000))
-                return 0;
-
-            const ArchiveFontBinaryLayout* font;
             const HeaderedGlyphGroups* pGlgr;
+            const ArchiveFontBinaryLayout* font;
 
             u16 countName, countSheet, count0A, count0C;
 
-            u32 stepSheets;
-            u32 step0A;
-            u32 step0C;
+            u32 stepSheets, step0A, step0C;
 
-            u32 dataSheetsOff;
-            u32 data0AOff;
-            u32 data0COff;
+            u32 dataSheetsOff, data0AOff, data0COff;
             const u32* dataSheets;
             const u32* data0A;
             const u32* data0C;
 
-            u32 flagsSheetsOff;
-            u32 flags0AOff;
-            u32 flags0COff;
+            u32 flagsSheetsOff, flags0AOff, flags0COff;
             const u32* flagsSheets;
             const u32* flags0A;
             const u32* flags0C;
 
-            u32 loadedSheetCount;
-            u32 loadedSmth0ASize;
-            u32 loadedSmth0CSize;
-
-            int wordI;
+            int wordI, j;
+            int entryI;
+            const HeaderedGlyphGroups* offsetPGlgr;
+            u32 loadedSheetCount, loadedSmth0ASize, loadedSmth0CSize;
             u32 flagWord;
             const u8* offsetFlags;
-            int j;
+            const char* groupName;
+            const u32* offsetData;
+
+            u32 sheetOffsetsSize;
+            u32 loadedSheetsSize;
+            u32 neededCharacterSize;
+            u32 baseSize;
+
+            if (!ArchiveFontBase::IsValidResource(fontData, 0x4000))
+                return 0;
 
             font = (ArchiveFontBinaryLayout*)fontData;
             pGlgr = &font->glgr;
@@ -67,89 +66,81 @@ namespace nw4r {
             dataSheetsOff = ROUNDUP(offsetof(ArchiveFontBinaryLayout, glgr.inner.nameOffsets) + countName * sizeof(u16), 4);
             data0AOff = ROUNDUP(dataSheetsOff + countSheet * sizeof(u32), 4);
             data0COff = ROUNDUP(data0AOff + count0A * sizeof(u32), 4);
+            dataSheets = lyt::detail::ConvertOffsToPtr<u32>(fontData, dataSheetsOff);
+            data0A = lyt::detail::ConvertOffsToPtr<u32>(fontData, data0AOff);
+            data0C = lyt::detail::ConvertOffsToPtr<u32>(fontData, data0COff);
 
             flagsSheetsOff = ROUNDUP(data0COff + count0C * sizeof(u32), 4);
             flags0AOff = ROUNDUP(flagsSheetsOff + stepSheets * countName, 4);
             flags0COff = ROUNDUP(flags0AOff + step0A * countName, 4);
 
-            dataSheets = (const u32*)fontData + (dataSheetsOff >> 2);
-            data0A = (const u32*)fontData + (data0AOff >> 2);
-            data0C = (const u32*)fontData + (data0COff >> 2);
-
-            flagsSheets = (const u32*)fontData + (flagsSheetsOff >> 2);
-            flags0A = (const u32*)fontData + (flags0AOff >> 2);
-            flags0C = (const u32*)fontData + (flags0COff >> 2);
+            flagsSheets = lyt::detail::ConvertOffsToPtr<u32>(fontData, flagsSheetsOff);
+            flags0A = lyt::detail::ConvertOffsToPtr<u32>(fontData, flags0AOff);
+            flags0C = lyt::detail::ConvertOffsToPtr<u32>(fontData, flags0COff);
 
             loadedSheetCount = 0;
             loadedSmth0ASize = 0;
             loadedSmth0CSize = 0;
 
             // Get the NUMBER of sheets that should be loaded
-            for (wordI = 0; wordI * 32 < pGlgr->inner.sheetCount; wordI += 1) {
+            for (wordI = 0, entryI = 0; entryI < pGlgr->inner.sheetCount; entryI += 0x20, wordI++) {
                 offsetFlags = (const u8*)flagsSheets + wordI * sizeof(u32);
 
                 flagWord = 0;
-                for (j = 0; j < pGlgr->inner.nameCount; j++) {
-                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                for (j = 0, offsetPGlgr = pGlgr; j < pGlgr->inner.nameCount;
+                     offsetPGlgr = (const HeaderedGlyphGroups*)((const u8*)offsetPGlgr + 2), j++) {
+                    groupName = (const char*)fontData + offsetPGlgr->inner.nameOffsets[0];
                     if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
                         flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * stepSheets, 4));
                     }
                 }
-                // u32 flagsSheet = getFlagsForWord(pGlgr, (const u32*)offsetFlags, stepSheets, fontData, includedGroups);
 
                 loadedSheetCount += math::CntBit1(flagWord);
             }
             // getLoadedSheetCount(pGlgr, flagsSheets, stepSheets, fontData, includedGroups, &loadedSheetCount);
 
             // Get the SIZE of unk_0x0a that should be loaded
-            for (wordI = 0; wordI * 32 < pGlgr->inner.smthCount_0x0a; wordI += 1) {
+            for (wordI = 0, entryI = 0; entryI < pGlgr->inner.smthCount_0x0a; entryI += 0x20, wordI++) {
                 offsetFlags = (const u8*)flags0A + wordI * sizeof(u32);
 
                 flagWord = 0;
                 for (j = 0; j < pGlgr->inner.nameCount; j++) {
-                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                    groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
                     if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
                         flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * step0A, 4));
                     }
                 }
 
-                const u32* offsetData = (const u32*)data0A + wordI * 32;
+                offsetData = (const u32*)data0A + wordI * 32;
                 for (j = 0; j < 32; j++) {
                     if ((flagWord << j) & 0x80000000U)
                         loadedSmth0ASize += offsetData[j] - sizeof(BinaryBlockHeader);
                 }
             }
-            // getLoadedSmth0ASize(pGlgr, flags0A, data0A, step0A, fontData, includedGroups, &loadedSmth0ASize);
 
             // Get the SIZE of unk_0x0c that should be loaded
-            for (wordI = 0; wordI * 32 < pGlgr->inner.smthCount_0x0c; wordI += 1) {
+            for (wordI = 0, entryI = 0; entryI < pGlgr->inner.smthCount_0x0c; entryI += 0x20, wordI++) {
                 offsetFlags = (const u8*)flags0C + wordI * sizeof(u32);
 
                 flagWord = 0;
                 for (j = 0; j < pGlgr->inner.nameCount; j++) {
-                    const char* groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
+                    groupName = (const char*)fontData + pGlgr->inner.nameOffsets[j];
                     if (*includedGroups == '\0' || detail::ArchiveFontBase::IncludeName(includedGroups, groupName)) {
                         flagWord |= *(const u32*)((const u8*)offsetFlags + ROUNDDOWN(j * step0C, 4));
                     }
                 }
 
-                const u32* offsetData = (const u32*)data0C + wordI * 32;
+                offsetData = (const u32*)data0C + wordI * 32;
                 for (j = 0; j < 32; j++) {
                     if ((flagWord << j) & 0x80000000U)
                         loadedSmth0CSize += offsetData[j] - sizeof(BinaryBlockHeader);
                 }
             }
-            // getLoadedSmth0CSize(pGlgr, flags0C, data0C, step0C, fontData, includedGroups, &loadedSmth0CSize);
 
             // Calculate the final buffer size based on the three previously
             // accessed components
-            u32 sheetOffsetsSize;
-            u32 loadedSheetsSize;
-            u32 neededCharacterSize;
-            u32 baseSize;
-
-            loadedSheetsSize = ROUNDUP(loadedSheetCount * pGlgr->inner.uncompSheetSize, 4);
             sheetOffsetsSize = ROUNDUP(pGlgr->inner.sheetCount * 2, 4);
+            loadedSheetsSize = ROUNDUP(loadedSheetCount * pGlgr->inner.uncompSheetSize, 4);
 
             neededCharacterSize = sizeof(CXUncompContextHuffman);
             if (loadedSmth0ASize + loadedSmth0CSize >= sizeof(CXUncompContextHuffman))
@@ -157,8 +148,6 @@ namespace nw4r {
 
             baseSize = ROUNDUP(sizeof(FontInformation) + sizeof(FontTextureGlyph) + sheetOffsetsSize, 0x20);
             return baseSize + neededCharacterSize + loadedSheetsSize;
-
-            // return totalBufferSize(pGlgr, loadedSheetCount, loadedSmth0ASize, loadedSmth0CSize);
         }
 
         detail::ArchiveFontBase::ConstructState ArchiveFont::StreamingConstruct(ConstructContext* ctx, const void* fontData, u32 fontDataSize) {
@@ -234,7 +223,6 @@ namespace nw4r {
             }
             return state;
         }
-
         bool ArchiveFont::Construct(void* work, u32 workSize, const void* fontData, const char* includedGroups) {
             u32 fontDataSize = ((BinaryFileHeader*)fontData)->fileSize;
 

--- a/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
@@ -4,77 +4,120 @@
 
 #include <string.h>
 
-#define FORCE_REACCESS_1(VAR, T) (T) * (volatile u8*)&VAR
+// Fakematch enablers
 #define FORCE_REACCESS_2(VAR, T) (T) * (volatile u16*)&VAR
 #define FORCE_REACCESS_4(VAR, T) (T) * (volatile u32*)&VAR
-#define FORCE_REACCESS_8(VAR, T) (T) * (volatile u64*)&VAR
 
 namespace nw4r {
     namespace ut {
         namespace detail {
-            u8* ArchiveFontBase::CachedStreamReader::getDataCurr() {
-                return pDataCurr;
+#define GLYPH_INDEX_NOT_FOUND 0xFFFF
+            typedef union {
+                u16 formatRaw;
+                struct {
+                    u16 isCmpr : 1;   // 0x00:1000000000000000
+                    u16 format : 15;  // 0x01:0111111111111111
+                };
+            } FlaggedImageFormat;
+
+            // CachedStreamReader inlined
+            u32 ArchiveFontBase::CachedStreamReader::getCurrentOffset() {
+                return (pDataCurr - pDataStart) + (pCachedStart - pCachedBase);
             }
-            u8* ArchiveFontBase::CachedStreamReader::advanceData(u32 len) {
-                u8* ret = getDataCurr();
-                pDataCurr = pDataCurr + len;
-                return ret;
-            }
-            size_t ArchiveFontBase::CachedStreamReader::amtAvailableData() {
-                return FORCE_REACCESS_4(pDataEnd, u8*) - FORCE_REACCESS_4(pDataCurr, u8*);
-            }
-            size_t ArchiveFontBase::CachedStreamReader::amtAvailableCached() {
-                return FORCE_REACCESS_4(pCachedEnd, u8*) - FORCE_REACCESS_4(pCachedStart, u8*);
-            }
-            size_t ArchiveFontBase::CachedStreamReader::amtAvailable() {
-                u32 availableCached = pCachedEnd - pCachedStart;
-                u32 availableData = pDataEnd - pDataCurr;
-                return FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
-            }
+
             size_t ArchiveFontBase::CachedStreamReader::amtAvailableRevLoadOrder() {
-                u32 availableData = pDataEnd - pDataCurr;
-                u32 availableCached = pCachedEnd - pCachedStart;
-                return FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
+                u32 availableData = amtAvailableData();
+                u32 availableCached = amtAvailableCached();
+                return availableData + FORCE_REACCESS_4(availableCached, u32);
             }
-            void ArchiveFontBase::CachedStreamReader::copyBugged(void* dst, u32 len) {
-                u32 cachedLen = pCachedEnd - pCachedStart;
-                if (len <= cachedLen) {
-                    memmove(dst, pCachedStart, len);
-                    pCachedStart += len;
-                } else {
-                    memmove(dst, pCachedStart, cachedLen);
-                    // @bug Should be dst + cachedLen
-                    memmove(dst, FORCE_REACCESS_4(pDataCurr, u8*), len - cachedLen);
-                    pCachedStart = pCachedEnd;
-                    pDataCurr += len - cachedLen;
-                }
-            }
-            void ArchiveFontBase::CachedStreamReader::memcpyToWork(ArchiveFontBase::ConstructContext& ctx, u32 copyLen) {
-                u32 cachedLen = amtAvailableCached();
-                u8* dst = FORCE_REACCESS_4(ctx.pWorkCurr, u8*);
+
+            void ArchiveFontBase::CachedStreamReader::memcpyToBufRev(void* _dst, u32 copyLen) {
+                u32 dataLen;
+                u8* dst;
+                u32 cachedLen;
+
+                u8* cachedStart;
+                u8* cachedEnd;
+
+                dst = (u8*)_dst;
+                cachedStart = pCachedStart;
+                cachedEnd = pCachedEnd;
+                cachedLen = cachedEnd - cachedStart;
                 if (cachedLen >= copyLen) {
-                    memcpy(dst, pCachedStart, copyLen);
-                    pCachedStart = FORCE_REACCESS_4(pCachedStart, u8*) + copyLen;
+                    memcpy(dst, cachedStart, copyLen);
+                    pCachedStart += copyLen;
                 } else {
-                    u32 dataLen = copyLen - cachedLen;
-                    memcpy(dst, pCachedStart, cachedLen);
+                    dataLen = copyLen - cachedLen;
+                    memcpy(dst, cachedStart, cachedLen);
                     memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
-                    pCachedStart = FORCE_REACCESS_4(pCachedEnd, u8*);
+                    pCachedStart = pCachedEnd;
                     pDataCurr = pDataCurr + dataLen;
                 }
             }
-            void ArchiveFontBase::CachedStreamReader::copyMemmove(void* dst, u32 len) {
-                u32 cachedLen = pCachedEnd - pCachedStart;
-                if (len <= cachedLen) {
-                    memmove(dst, pCachedStart, len);
-                    pCachedStart += len;
+            void ArchiveFontBase::CachedStreamReader::memcpyToBufReaccess(void* _dst, u32 copyLen) {
+                u32 cachedLen;
+                u8* dst;
+                u32 dataLen;
+
+                u8* cachedStart;
+                u8* cachedEnd;
+
+                dst = (u8*)_dst;
+                cachedStart = FORCE_REACCESS_4(pCachedStart, u8*);
+                cachedEnd = FORCE_REACCESS_4(pCachedEnd, u8*);
+                cachedLen = cachedEnd - cachedStart;
+                if (cachedLen >= copyLen) {
+                    memcpy(dst, cachedStart, copyLen);
+                    pCachedStart += copyLen;
                 } else {
-                    memmove(dst, pCachedStart, cachedLen);
-                    memmove((u8*)dst + cachedLen, pDataCurr, len - cachedLen);
+                    dataLen = copyLen - cachedLen;
+                    memcpy(dst, cachedStart, cachedLen);
+                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
                     pCachedStart = pCachedEnd;
-                    pDataCurr += len - cachedLen;
+                    pDataCurr += dataLen;
                 }
             }
+            void ArchiveFontBase::CachedStreamReader::memcpyToBuf(void* _dst, u32 copyLen) {
+                u32 cachedLen;
+                u8* dst;
+                u32 dataLen;
+
+                u8* cachedStart;
+                u8* cachedEnd;
+
+                dst = (u8*)_dst;
+                cachedStart = pCachedStart;
+                cachedEnd = pCachedEnd;
+                cachedLen = cachedEnd - cachedStart;
+                if (cachedLen >= copyLen) {
+                    memcpy(dst, cachedStart, copyLen);
+                    pCachedStart += copyLen;
+                } else {
+                    dataLen = copyLen - cachedLen;
+                    memcpy(dst, cachedStart, cachedLen);
+                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
+                    pCachedStart = pCachedEnd;
+                    pDataCurr += dataLen;
+                }
+            }
+            void ArchiveFontBase::CachedStreamReader::skipReaccess(u32 skipLen) {
+                u8* start;
+                u32 dataLen, cachedLen;
+                u8* end;
+
+                end = FORCE_REACCESS_4(pCachedEnd, u8*);
+                start = FORCE_REACCESS_4(pCachedStart, u8*);
+                cachedLen = end - start;
+                if (cachedLen > skipLen) {
+                    pCachedStart = start + skipLen;
+                } else {
+                    dataLen = skipLen - cachedLen;
+                    pCachedStart = end;
+                    pDataCurr += dataLen;
+                }
+            }
+
+            // CachedStreamReader retained
             void ArchiveFontBase::CachedStreamReader::Init() {
                 pDataStart = NULL;
                 pDataCurr = NULL;
@@ -86,30 +129,48 @@ namespace nw4r {
 
                 unk_0x18 = 0;
             }
-            void ArchiveFontBase::CachedStreamReader::Attach(void* data, u32 dataLen) {
+            void ArchiveFontBase::CachedStreamReader::Attach(const void* data, u32 dataLen) {
                 pDataStart = (u8*)data;
                 pDataCurr = (u8*)data;
                 pDataEnd = (u8*)data + dataLen;
             }
-            bool ArchiveFontBase::CachedStreamReader::RequestData(ArchiveFontBase::ConstructContext& ctx, u32 offset) {
-                size_t available = amtAvailableRevLoadOrder();
+
+            bool ArchiveFontBase::CachedStreamReader::RequestData(ArchiveFontBase::ConstructContext* ctx, u32 offset) {
+                size_t dataLen;
+                size_t cachedLen;
+                size_t available;
+
+                u8* cachedEnd;
+                u8* cachedStart;
+                u8* workCurr;
+                u8* dst;
+
+                u32 availableData, availableCached;
+
+                availableData = pDataEnd - pDataCurr;
+                availableCached = pCachedEnd - pCachedStart;
+                available = FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
                 if (available == 0) {
                     pCachedBase = NULL;
                     pCachedStart = NULL;
                     pCachedEnd = NULL;
                     unk_0x18 = 0;
                 } else {
-                    if (ctx.remWorkSpace() < (offset << 1))
+                    if (ctx->remWorkSpace() < (offset << 1))
                         return false;
-                    size_t cachedLen = amtAvailableCached();
+                    cachedStart = FORCE_REACCESS_4(pCachedStart, u8*);
+                    cachedEnd = FORCE_REACCESS_4(pCachedEnd, u8*);
+                    workCurr = FORCE_REACCESS_4(ctx->pWorkCurr, u8*);
+                    // return ;
+                    cachedLen = cachedEnd - cachedStart;
 
-                    u8* dst = FORCE_REACCESS_4(ctx.pWorkCurr, u8*) + offset;
+                    dst = workCurr + offset;
                     if (cachedLen >= available) {
-                        memmove(dst, pCachedStart, available);
+                        memmove(dst, cachedStart, available);
                         pCachedStart += available;
                     } else {
-                        u32 dataLen = available - cachedLen;
-                        memmove(dst, pCachedStart, cachedLen);
+                        dataLen = available - cachedLen;
+                        memmove(dst, cachedStart, cachedLen);
                         memmove(dst + cachedLen, pDataCurr, dataLen);
                         pCachedStart = pCachedEnd;
                         pDataCurr = FORCE_REACCESS_4(pDataCurr, u8*) + dataLen;
@@ -122,142 +183,534 @@ namespace nw4r {
                 return true;
             }
 
-            u32 ArchiveFontBase::ConstructContext::remWorkSpace() {
-                return FORCE_REACCESS_4(pWorkEnd, u8*) - FORCE_REACCESS_4(pWorkCurr, u8*);
+            // ConstructContext inlined
+            u32 ArchiveFontBase::ConstructContext::remWorkSpace() const {
+                return pWorkEnd - pWorkCurr;
             }
-            void ArchiveFontBase::ConstructContext::updateDataOffset(CachedStreamReader& reader) {
-                mDataOffset += (u32)(reader.pDataCurr - reader.pDataStart) + (reader.pCachedStart - reader.pCachedBase);
+            void ArchiveFontBase::ConstructContext::updateDataOffset(CachedStreamReader* reader) {
+                mDataOffset += (u32)(reader->pDataCurr - reader->pDataStart) + (reader->pCachedStart - reader->pCachedBase);
             }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructContext::requestNewData(CachedStreamReader& reader, u32 amt) {
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructContext::requestNewData(CachedStreamReader* reader, u32 amt) {
                 updateDataOffset(reader);
-                bool requestSucceeded = reader.RequestData(*this, amt);
+                bool requestSucceeded = reader->RequestData(this, amt);
                 if (requestSucceeded)
                     return CONSTRUCT_STATE_DATA_REQUESTED;
                 else
                     return CONSTRUCT_STATE_FATAL_ERR;
             }
+            void ArchiveFontBase::ConstructContext::getNumSheetsToLoad(u16* sheetsToLoad) const {
+                *sheetsToLoad = 0;
+                for (int i = 0; i < mSheetCount; i++) {
+                    if (pSheetOffsets[i] != GLYPH_INDEX_NOT_FOUND)
+                        (*sheetsToLoad)++;
+                }
+            }
+            u16 ArchiveFontBase::ConstructContext::updateTextureBlockFormat() {
+                FlaggedImageFormat origSheetFormat;
+                origSheetFormat.formatRaw = pFontInfo->pGlyph->sheetFormat;
+                pFontInfo->pGlyph->sheetFormat = origSheetFormat.format;
+                return origSheetFormat.isCmpr;
+            }
+            u32 ArchiveFontBase::ConstructContext::updateTextureBlockPtr() {
+                u32 imgDataOffset;
+                imgDataOffset = (u32)pFontInfo->pGlyph->sheetImage;
+                u8* paddedWork = (u8*)(((u32)pWorkCurr + 0x1f) & (~0x1f));
+                pWorkCurr = paddedWork;
 
+                pFontInfo->pGlyph->sheetImage = paddedWork;
+
+                return imgDataOffset;
+            }
+
+            // ArchiveFontBase retained
             ArchiveFontBase::ArchiveFontBase() : pSheetOffsets(NULL) {
             }
             ArchiveFontBase::~ArchiveFontBase() {
             }
 
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFileHeader(ConstructContext& ctx, CachedStreamReader& reader) {
-                int iVar1;
-                void* cacheStart;
-                u32 cachedLen;
-                void* fileHdrDest;
-                if (reader.amtAvailable() < sizeof(BinaryFileHeader)) {
-                    ctx.updateDataOffset(reader);
-                    bool requestSucceeded = reader.RequestData(ctx, sizeof(BinaryFileHeader));
+            CharWidths ArchiveFontBase::GetCharWidths(u16 charcode) const {
+                u16 glyphIdx, adjGlyphIdx;
+
+                glyphIdx = GetGlyphIndex(charcode);
+                adjGlyphIdx = AdjustIndex(glyphIdx);
+                if (adjGlyphIdx == GLYPH_INDEX_NOT_FOUND) {
+                    glyphIdx = mFontInfo->alterCharIndex;
+                }
+                return GetCharWidthsFromIndex(glyphIdx);
+            }
+            void ArchiveFontBase::SetResourceBuffer(void* pUserBuffer, FontInformation* pFontInfo, u16* pSheetOffsets) {
+                ResFontBase::SetResourceBuffer(pUserBuffer, pFontInfo);
+                this->pSheetOffsets = pSheetOffsets;
+            }
+            u16 ArchiveFontBase::AdjustIndex(u16 glyphIdx) const {
+                FontTextureGlyph* pTglp = mFontInfo->pGlyph;
+                s32 glyphsPerSheet = (u32)pTglp->sheetRow * (u32)pTglp->sheetLine;
+                u32 originalSheetIdx = (s32)glyphIdx / glyphsPerSheet;
+                if (pSheetOffsets[originalSheetIdx] != GLYPH_INDEX_NOT_FOUND)
+                    return glyphIdx - pSheetOffsets[originalSheetIdx];
+                else
+                    return GLYPH_INDEX_NOT_FOUND;
+            }
+            bool ArchiveFontBase::IncludeName(const char* groupList, const char* group) {
+                u32 groupLen = strlen(group);
+                const char* substr = groupList - 1;
+                while (true) {
+                    substr = strstr(substr + 1, group);
+                    if (substr == NULL)
+                        return false;
+
+                    // Check that there is nothing but spaces between the substr
+                    // and the preceeding comma
+                    // - Fails:
+                    //   - groupList = "foo, BAD bar, baz"
+                    //   - substr                ^
+                    // - Succeeds:
+                    //   - groupList = "foo, bar, baz"
+                    //   - substr            ^
+                    // - Succeeds:
+                    //   - groupList = "foo,bar,baz"
+                    //   - substr           ^
+                    // - Succeeds:
+                    //   - groupList = "foo,bar,baz"
+                    //   - substr       ^
+                    // - Fails (I think this is a bug):
+                    //   - groupList = " foo, bar, baz"
+                    //   - substr        ^
+                    // @bug Should allow for leading spaces in groupList (maybe?)
+                    if (substr != groupList) {
+                        const char* backsearchStr = substr - 1;
+                        while (backsearchStr > groupList && *backsearchStr == ' ')
+                            backsearchStr--;
+                        if (*backsearchStr != ',')
+                            continue;
+                    }
+
+                    // Get the length of the section up until the next comma or
+                    // the end
+                    // - substr = "foo bar, baz"     -> sectionLen = 7
+                    // - substr = "foo        , baz" -> sectionLen = 11
+                    // - substr = "foo"              -> sectionLen = 3
+                    const char* nextComma = strchr(substr, ',');
+                    u32 sectionLen;
+                    if (nextComma != NULL)
+                        sectionLen = nextComma - substr;
+                    else
+                        sectionLen = strlen(substr);
+
+                    // Check to make sure there is nothing except spaces between
+                    // the end of the group name and the next comma:
+                    // - Fails:
+                    //   - substr = "foo bar, baz"
+                    //   - group = "foo"
+                    // - Succeeds:
+                    //   - substr = "foo     , baz"
+                    //   - group = "foo"
+                    // - Succeeds:
+                    //   - substr = "foo, baz"
+                    //   - group = "foo"
+                    const char* sectionEnd = substr + groupLen;
+                    while (sectionEnd < substr + sectionLen && (*sectionEnd == ' '))
+                        sectionEnd++;
+
+                    if (sectionEnd == substr + sectionLen)
+                        return true;
+                }
+            }
+            bool ArchiveFontBase::IsValidResource(const void* data, u32 maxPreFinfSize) {
+                const u8* fileBuf = (u8*)data;
+                const BinaryFileHeader* hdr = (const BinaryFileHeader*)fileBuf;
+                const BinaryBlockHeader* glgrHdr = (BinaryBlockHeader*)(fileBuf + sizeof(BinaryFileHeader));
+                if (!IsValidBinaryFile((const BinaryFileHeader*)fileBuf, SIGNATURE_FONT_ARCHIVE, VERSION, 2)) {
+                    return false;
+                } else if (glgrHdr->kind != SIGNATURE_GLYPH_GROUPS) {
+                    return false;
+                } else {
+                    return glgrHdr->size + 0x10 <= maxPreFinfSize;
+                }
+            }
+
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpDispatch(ConstructContext* ctx, CachedStreamReader* reader) {
+                void* nextBlockHdr;
+
+                if (ctx->mBlocksParsed >= ctx->mTotalBlocks)
+                    return CONSTRUCT_STATE_DONE;
+                if (reader->amtAvailable() < sizeof(BinaryBlockHeader))
+                    return ctx->requestNewData(reader, sizeof(BinaryBlockHeader));
+
+                reader->memcpyToBufReaccess(&ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
+                switch (ctx->mNextBlockHdr.kind) {
+                    case SIGNATURE_GLYPH_GROUPS:
+                        ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_GLGR;
+                        break;
+                    case SIGNATURE_FONT_INFO:
+                        ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_FINF;
+                        break;
+                    case SIGNATURE_CODE_MAP:
+                        ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_CMAP;
+                        break;
+                    case SIGNATURE_CHAR_WIDTH:
+                        ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_CWDH;
+                        break;
+                    case SIGNATURE_TEX_GLYPH:
+                        ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_TGLP;
+                        break;
+                    default:
+                        ctx->mNextCmd = CONSTRUCT_CMD_FATAL_ERR;
+                        return CONSTRUCT_STATE_FATAL_ERR;
+                }
+                ctx->mBlocksParsed++;
+                ctx->pWorkCurr = (u8*)(((u32)ctx->pWorkCurr + 3) & (~3));
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFileHeader(ConstructContext* ctx, CachedStreamReader* reader) {
+                if (reader->amtAvailable() < sizeof(BinaryFileHeader))
+                    return ctx->requestNewData(reader, sizeof(BinaryFileHeader));
+                if (ctx->remWorkSpace() < sizeof(BinaryFileHeader))
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                reader->memcpyToBufReaccess(ctx->pWorkCurr, sizeof(BinaryFileHeader));
+                ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
+                return CONSTRUCT_STATE_WORKING;
+            }
+
+            inline void copyGlgr(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBase::CachedStreamReader* reader, u32 glgrInnerLen) {
+                BinaryFileHeader* hdr;
+                BinaryBlockHeader* glgrHdr;
+                GlyphGroups* glgr;
+
+                hdr = (BinaryFileHeader*)ctx->pWorkCurr;
+
+                // Copy the glgr block header to work
+                glgrHdr = (BinaryBlockHeader*)((u8*)hdr + sizeof(BinaryFileHeader));
+                memcpy(glgrHdr, &ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
+
+                // Copy the glgr data to work
+                glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
+                reader->memcpyToBuf(glgr, glgrInnerLen);
+            }
+            inline void updateSheetFlags(const void* glgrHdr, u32 groupIdx, u16* sheetOffsets, u32 sheetFlagsSize, const u32* bitBlocksPtr) {
+                const GlyphGroups* glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
+                for (int sheetI = 0; sheetI < glgr->sheetCount; sheetI++) {
+                    u32 groupBitIdx = sheetI + groupIdx * sheetFlagsSize * 8;
+
+                    const u32* bitBlockPtr = bitBlocksPtr + (groupBitIdx & ~0x1f) / 32;
+                    u32 bitBlock = *(u32*)bitBlockPtr;
+                    if (((bitBlock << (groupBitIdx & 0x1f)) & 0x80000000) != 0)
+                        sheetOffsets[sheetI] = 1;
+                }
+            }
+            inline void setSheetOffsetBooleans(const ArchiveFontBase::ConstructContext* ctx, const void* glgrHdr, const void* hdr, u16* sheetOffsets,
+                                               const u32* bitBlocksPtr, u32 sheetFlagsSize) {
+                HeaderedGlyphGroups* pGlgr = (HeaderedGlyphGroups*)glgrHdr;
+
+                for (int i = 0; i < pGlgr->inner.sheetCount; i++)
+                    sheetOffsets[i] = 0;
+
+                for (int i = 0; i < pGlgr->inner.nameCount; i++) {
+                    const char* includedGroups = ctx->pIncludedGroups;
+                    u16 offset = pGlgr->inner.nameOffsets[i];
+                    char* name = (char*)((u8*)hdr + offset);
+                    if (*includedGroups != 0)
+                        if (!ArchiveFontBase::IncludeName(includedGroups, name))
+                            continue;
+
+                    updateSheetFlags(glgrHdr, i, sheetOffsets, sheetFlagsSize, bitBlocksPtr);
+                }
+            }
+            inline void convertSheetOffsetBooleansToOffsets(const void* glgrHdr, u16* sheetOffsets) {
+                HeaderedGlyphGroups* pGlgr = (HeaderedGlyphGroups*)glgrHdr;
+                u16 glyphIdxOffset = 0;
+                for (int i = 0; i < pGlgr->inner.sheetCount; i++) {
+                    if (sheetOffsets[i] == 1) {
+                        sheetOffsets[i] = glyphIdxOffset;
+                    } else {
+                        sheetOffsets[i] = -1;
+                        glyphIdxOffset += pGlgr->inner.sheetGlyphCount;
+                    }
+                }
+            }
+            inline void copyFlagOffsets(ArchiveFontBase::ConstructContext* ctx, u16* sheetOffsetsScratch, u32 workSize, u32 scratchSize) {
+                u8* sheetOffsets = ctx->pWorkCurr;
+                ctx->pWorkCurr = sheetOffsets + workSize;
+                memmove(sheetOffsets, sheetOffsetsScratch, scratchSize);
+                ctx->pSheetOffsets = (u16*)sheetOffsets;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeGLGR(ConstructContext* ctx, CachedStreamReader* reader) {
+                ArchiveFontBinaryLayout* font;
+                HeaderedGlyphGroups* glgrHdr;
+                u8* glgrEnd;
+
+                u32 expectedMaxSize;
+                u32 glgrFullLen, glgrInnerLen;
+
+                font = (ArchiveFontBinaryLayout*)ctx->pWorkCurr;
+
+                glgrFullLen = ctx->mNextBlockHdr.size;
+                glgrInnerLen = glgrFullLen - sizeof(BinaryBlockHeader);
+
+                // Check for RFNA
+                if (font->hdr.signature != SIGNATURE_FONT_ARCHIVE)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                // Check that there's enough data available, and the space to
+                // put that data
+                if (reader->amtAvailable() < glgrInnerLen)
+                    return ctx->requestNewData(reader, glgrInnerLen);
+                if (ctx->remWorkSpace() < glgrInnerLen)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                expectedMaxSize = glgrFullLen + sizeof(BinaryFileHeader);
+
+                // Copy the glgr to work
+                {
+                    glgrHdr = &font->glgr;
+                    glgrEnd = (u8*)glgrHdr + (u32)ctx->mNextBlockHdr.size;
+
+                    memcpy(glgrHdr, &ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
+                    reader->memcpyToBuf(&glgrHdr->inner, glgrInnerLen);
+                }
+
+                if (!ArchiveFontBase::IsValidResource(font, expectedMaxSize))
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                // Before here is fine (other than regswaps)
+
+                // return analyzeGlgrInner(ctx, font, glgrEnd);
+                u8* workCurr;
+                u32 fontSizeToEndOfGlgr;
+                u16 sheetGlyphCount, dataBlockCount;
+                u16 countNames, countSheets;
+                u32 sheetFlagsSize, sheetOffsetsSize;
+                u32* sheetFlagsPtr;
+                u32 remWorkSpace;
+                u16* sheetOffsetsScratch;
+                u32 workSizeNeeded;
+                u32 sheetOffsetsScratchSize;
+
+                workCurr = ctx->pWorkCurr;
+                glgrHdr = &font->glgr;
+
+                fontSizeToEndOfGlgr = glgrEnd - (u8*)font;
+
+                sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
+                dataBlockCount = font->hdr.dataBlocks;               // 0x0E
+
+                countNames = font->glgr.inner.nameCount;    // 0x1E
+                countSheets = font->glgr.inner.sheetCount;  // 0x20
+
+                // sheetFlagsSize, sheetOffsetsSize, sheetFlagsPtr
+                {
+                    sheetFlagsSize = CalcSizeSheetFlagSet(countSheets);
+                    sheetOffsetsSize = CalcSizeSheetOffsets(countSheets);
+                    sheetFlagsPtr =
+                        (u32*)(CalcOffsetSheetFlags(countNames, countSheets, font->glgr.inner.smthCount_0x0a, font->glgr.inner.smthCount_0x0c) +
+                               (u8*)font);
+                }
+                remWorkSpace = ctx->pWorkEnd - workCurr;
+
+                sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u8*)font + remWorkSpace) - sheetOffsetsSize, 2);
+
+                workSizeNeeded = fontSizeToEndOfGlgr + sheetOffsetsSize;
+                if (remWorkSpace < workSizeNeeded)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                setSheetOffsetBooleans(ctx, glgrHdr, font, sheetOffsetsScratch, sheetFlagsPtr, sheetFlagsSize);
+
+                convertSheetOffsetBooleansToOffsets(glgrHdr, sheetOffsetsScratch);
+
+                sheetOffsetsScratchSize = (u32)countSheets << 1;
+                sheetOffsetsScratchSize += (sheetOffsetsScratchSize >> 31);
+                sheetOffsetsScratchSize &= ~1;
+                copyFlagOffsets(ctx, sheetOffsetsScratch, sheetOffsetsSize, sheetOffsetsScratchSize);
+
+                ctx->mSheetCount = countSheets;
+                ctx->mGlyphsPerSheet = sheetGlyphCount;
+                ctx->mTotalBlocks = dataBlockCount;
+                ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
+
+                return CONSTRUCT_STATE_WORKING;
+            }
+
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFINF(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 innerSize;
+
+                innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
+                if (ctx->remWorkSpace() < innerSize)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                ctx->pFontInfo = (FontInformation*)ctx->pWorkCurr;
+
+                ctx->enqueueCmds(CONSTRUCT_CMD_COPY, innerSize, CONSTRUCT_CMD_DISPATCH);
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeCMAP(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 innerSize;
+
+                ctx->pushCMAP();
+
+                innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
+                if (ctx->remWorkSpace() < innerSize)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                ctx->enqueueCmds(CONSTRUCT_CMD_COPY, innerSize, CONSTRUCT_CMD_DISPATCH);
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeCWDH(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 innerSize;
+
+                ctx->pushCWDH();
+
+                innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
+                if (ctx->remWorkSpace() < innerSize)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                ctx->enqueueCmds(CONSTRUCT_CMD_COPY, innerSize, CONSTRUCT_CMD_DISPATCH);
+                return CONSTRUCT_STATE_WORKING;
+            }
+
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeTGLP(ConstructContext* ctx, CachedStreamReader* reader) {
+                ConstructCmd prepCmd;
+                u16 isCmpr;
+                u32 imgDataOffset;
+                FlaggedImageFormat origSheetFormat;
+                u16 sheetsToLoad;
+
+                if (reader->amtAvailable() < sizeof(FontTextureGlyph))
+                    return ctx->requestNewData(reader, sizeof(FontTextureGlyph));
+                if (ctx->remWorkSpace() < sizeof(FontTextureGlyph))
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                ctx->pFontInfo->pGlyph = (FontTextureGlyph*)ctx->pWorkCurr;
+                reader->memcpyToBufRev(ctx->pWorkCurr, sizeof(FontTextureGlyph));
+                ctx->pWorkCurr += sizeof(FontTextureGlyph);
+
+                origSheetFormat.formatRaw = ctx->pFontInfo->pGlyph->sheetFormat;
+                ctx->pFontInfo->pGlyph->sheetFormat = origSheetFormat.format;
+                isCmpr = origSheetFormat.isCmpr;
+
+                ctx->getNumSheetsToLoad(&sheetsToLoad);
+                ctx->pFontInfo->pGlyph->sheetNum = sheetsToLoad;
+
+                imgDataOffset = ctx->updateTextureBlockPtr();
+
+                prepCmd = isCmpr ? CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET : CONSTRUCT_CMD_PREPAIR_COPY_SHEET;
+
+                ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, imgDataOffset - (ctx->mDataOffset + reader->getCurrentOffset()), prepCmd);
+                return CONSTRUCT_STATE_WORKING;
+            }
+
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpPrepairCopySheet(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 sheetSize;
+
+                if (ctx->mSheetsHandled >= ctx->mSheetCount) {
+                    ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
+                    return CONSTRUCT_STATE_WORKING;
+                }
+                sheetSize = ctx->pFontInfo->pGlyph->sheetSize;
+                if (ctx->pSheetOffsets[ctx->mSheetsHandled] != GLYPH_INDEX_NOT_FOUND) {
+                    if (ctx->remWorkSpace() < sheetSize)
+                        return CONSTRUCT_STATE_FATAL_ERR;
+                    ctx->enqueueCmds(CONSTRUCT_CMD_COPY, sheetSize, CONSTRUCT_CMD_PREPAIR_COPY_SHEET);
+                } else {
+                    ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, sheetSize, CONSTRUCT_CMD_PREPAIR_COPY_SHEET);
+                }
+                ctx->mSheetsHandled++;
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpPrepairExpandSheet(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 compressedSize, uncompressedSize;
+                u8 compressedSizeBuf[4];
+                u8 compressedDataHdr[4];
+
+                if (ctx->mSheetsHandled >= ctx->mSheetCount) {
+                    ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
+                    return CONSTRUCT_STATE_WORKING;
+                }
+                if (reader->amtAvailable() < 8) {
+                    ctx->updateDataOffset(reader);
+                    bool requestSucceeded = reader->RequestData(ctx, 8);
                     if (requestSucceeded)
                         return CONSTRUCT_STATE_DATA_REQUESTED;
                     else
                         return CONSTRUCT_STATE_FATAL_ERR;
                 }
-                if (ctx.remWorkSpace() < sizeof(BinaryFileHeader))
-                    return CONSTRUCT_STATE_FATAL_ERR;
-                reader.memcpyToWork(ctx, sizeof(BinaryFileHeader));
-                ctx.mNextCmd = CONSTRUCT_CMD_DISPATCH;
+                reader->memcpyToBufReaccess(compressedSizeBuf, 4);
+                memcpy(compressedDataHdr, reader->pDataCurr, 4);
+                compressedSize = *(u32*)(u8*)compressedSizeBuf;
+
+                uncompressedSize = CXGetUncompressedSize(compressedDataHdr);
+                if (ctx->pSheetOffsets[ctx->mSheetsHandled] != GLYPH_INDEX_NOT_FOUND) {
+                    if (ctx->remWorkSpace() < compressedSize + sizeof(CXUncompContextHuffman))
+                        return CONSTRUCT_STATE_FATAL_ERR;
+
+                    CXInitUncompContextHuffman(ctx->pHuffmanCtx, ctx->pWorkCurr);
+
+                    ctx->enqueueCmds(CONSTRUCT_CMD_EXPAND, compressedSize, CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET);
+                    ctx->pWorkCurr += uncompressedSize;
+                } else {
+                    ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, compressedSize, CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET);
+                }
+                ctx->mSheetsHandled++;
                 return CONSTRUCT_STATE_WORKING;
             }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFINF(ConstructContext& ctx) {
-                u32 finfInnerSize = ctx.mNextBlockLen - 8;
-                if (ctx.remWorkSpace() < finfInnerSize)
-                    return CONSTRUCT_STATE_FATAL_ERR;
 
-                ctx.mNextCmdParam = finfInnerSize;
-                ctx.pFinf = (FontInformation*)FORCE_REACCESS_4(ctx.pWorkCurr, u8*);
+            ArchiveFontBase::ConstructState ArchiveFontBase::handleAdvanceDry(ConstructContext* ctx, CachedStreamReader* reader, u32 advanced) {
+                advanced = ut::Min(advanced, ctx->mNextCmdParam);
 
-                ctx.mNextCmd = CONSTRUCT_CMD_COPY;
-                ctx.mQueuedCmd = CONSTRUCT_CMD_DISPATCH;
-                return CONSTRUCT_STATE_WORKING;
-            }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpCopy(ConstructContext& ctx, CachedStreamReader& reader) {
-                ConstructState newState;
-                u32 copySize = reader.pDataEnd - reader.pDataCurr;
-                // u32 totalCopySize = ctx.mNextCmdParam;
-                if (copySize <= ctx.mNextCmdParam)
-                    ;
+                ctx->mNextCmdParam -= advanced;
+                if (ctx->mNextCmdParam == 0)
+                    ctx->mNextCmd = ctx->mQueuedCmd;
                 else
-                    copySize = ctx.mNextCmdParam;
-                memcpy(ctx.pWorkCurr, reader.pDataCurr, copySize);
-                reader.pDataCurr += copySize;
-                ctx.pWorkCurr += copySize;
-                if (copySize <= ctx.mNextCmdParam)
-                    ;
-                else
-                    copySize = FORCE_REACCESS_4(ctx.mNextCmdParam, u32);
-                u32 remaining = ctx.mNextCmdParam - copySize;
-                ctx.mNextCmdParam = remaining;
-                if (remaining == 0) {
-                    ctx.mNextCmd = ctx.mQueuedCmd;
-                    newState = CONSTRUCT_STATE_WORKING;
-                } else {
-                    return ctx.requestNewData(reader, remaining);
-                }
-                return newState;
+                    return ctx->requestNewData(reader, ctx->mNextCmdParam);
+
+                return ArchiveFontBase::CONSTRUCT_STATE_WORKING;
             }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpSkip(ConstructContext& ctx, CachedStreamReader& reader) {
-                ConstructState newState;
-                register u32 copySize = ctx.mNextCmdParam;
-                register u32 available = reader.amtAvailable();
-                if (available < ctx.mNextCmdParam)
-                    copySize = available;
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpCopy(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 copySize;
+                copySize = ut::Min(reader->amtAvailableData(), ctx->mNextCmdParam);
 
-                available = reader.amtAvailableCached();
-                if (copySize < available) {
-                    reader.pCachedStart += copySize;
-                } else {
-                    reader.pDataCurr += copySize - available;
-                    reader.pCachedStart = reader.pCachedEnd;
-                }
+                memcpy(ctx->pWorkCurr, reader->pDataCurr, copySize);
+                reader->pDataCurr += copySize;
+                ctx->pWorkCurr += copySize;
 
-                if (ctx.mNextCmdParam < copySize)
-                    copySize = ctx.mNextCmdParam;
-                register u32 remaining = ctx.mNextCmdParam - copySize;
-                if (remaining == 0) {
-                    ctx.mNextCmd = ctx.mQueuedCmd;
-                    newState = CONSTRUCT_STATE_WORKING;
-                } else {
-                    return ctx.requestNewData(reader, remaining);
-                }
-                return newState;
+                return handleAdvanceDry(ctx, reader, copySize);
             }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpExpand(ConstructContext& ctx, CachedStreamReader& reader) {
-                ConstructState nextState;
-                // register u32 available = reader.pDataEnd - reader.pDataCurr;
-                // register u32 availableCached = reader.pCachedEnd - reader.pCachedStart;
-                // available += availableCached;
-                register u32 available = reader.amtAvailableRevLoadOrder();
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpSkip(ConstructContext* ctx, CachedStreamReader* reader) {
+                u8* start;
+                u32 dataLen, cachedLen;
+                u8* end;
 
-                register u32 cmprSize;
-                {
-                    if (ctx.mNextCmdParam > available)
-                        cmprSize = available;
-                    else
-                        cmprSize = ctx.mNextCmdParam;
-                }
+                u32 skipSize;
 
-                // u8* cmprBuf = reader.advanceData(cmprSize);
-                CXReadUncompHuffman(ctx.pHuffmanCtx, reader.advanceData(cmprSize), cmprSize);
+                skipSize = ut::Min(ctx->mNextCmdParam, reader->amtAvailable());
 
-                u32 nextCmdParam = ctx.mNextCmdParam;
-                if (cmprSize > nextCmdParam)
-                    cmprSize = nextCmdParam;
-                register u32 remaining = FORCE_REACCESS_4(ctx.mNextCmdParam, u32) - cmprSize;
-                ctx.mNextCmdParam = remaining;
-
-                if (remaining == 0) {
-                    ctx.mNextCmd = ctx.mQueuedCmd;
-                    nextState = CONSTRUCT_STATE_WORKING;
+                end = FORCE_REACCESS_4(reader->pCachedEnd, u8*);
+                start = FORCE_REACCESS_4(reader->pCachedStart, u8*);
+                cachedLen = end - start;
+                if (cachedLen > skipSize) {
+                    reader->pCachedStart = start + skipSize;
                 } else {
-                    return ctx.requestNewData(reader, remaining);
+                    dataLen = skipSize - cachedLen;
+                    reader->pCachedStart = end;
+                    reader->pDataCurr += dataLen;
                 }
-                return nextState;
+
+                return handleAdvanceDry(ctx, reader, skipSize);
             }
-            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpFatalErr(ConstructContext& ctx) {
-                ctx.mNextCmd = CONSTRUCT_CMD_FATAL_ERR;
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpExpand(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 cmprSize;
+                u8* src;
+
+                cmprSize = ut::Min(ctx->mNextCmdParam, reader->amtAvailableRevLoadOrder());
+
+                src = reader->pDataCurr;
+                reader->pDataCurr += cmprSize;
+                CXReadUncompHuffman(ctx->pHuffmanCtx, src, cmprSize);
+
+                return handleAdvanceDry(ctx, reader, cmprSize);
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpFatalError(ConstructContext* ctx, CachedStreamReader* reader) {
+                ctx->mNextCmd = CONSTRUCT_CMD_FATAL_ERR;
                 return CONSTRUCT_STATE_FATAL_ERR;
             }
         }  // namespace detail

--- a/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
@@ -1,0 +1,265 @@
+#include <nw4r/ut/ArchiveFont.h>
+#include <nw4r/ut/Font.h>
+#include <nw4r/ut/fontResources.h>
+
+#include <string.h>
+
+#define FORCE_REACCESS_1(VAR, T) (T) * (volatile u8*)&VAR
+#define FORCE_REACCESS_2(VAR, T) (T) * (volatile u16*)&VAR
+#define FORCE_REACCESS_4(VAR, T) (T) * (volatile u32*)&VAR
+#define FORCE_REACCESS_8(VAR, T) (T) * (volatile u64*)&VAR
+
+namespace nw4r {
+    namespace ut {
+        namespace detail {
+            u8* ArchiveFontBase::CachedStreamReader::getDataCurr() {
+                return pDataCurr;
+            }
+            u8* ArchiveFontBase::CachedStreamReader::advanceData(u32 len) {
+                u8* ret = getDataCurr();
+                pDataCurr = pDataCurr + len;
+                return ret;
+            }
+            size_t ArchiveFontBase::CachedStreamReader::amtAvailableData() {
+                return FORCE_REACCESS_4(pDataEnd, u8*) - FORCE_REACCESS_4(pDataCurr, u8*);
+            }
+            size_t ArchiveFontBase::CachedStreamReader::amtAvailableCached() {
+                return FORCE_REACCESS_4(pCachedEnd, u8*) - FORCE_REACCESS_4(pCachedStart, u8*);
+            }
+            size_t ArchiveFontBase::CachedStreamReader::amtAvailable() {
+                u32 availableCached = pCachedEnd - pCachedStart;
+                u32 availableData = pDataEnd - pDataCurr;
+                return FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
+            }
+            size_t ArchiveFontBase::CachedStreamReader::amtAvailableRevLoadOrder() {
+                u32 availableData = pDataEnd - pDataCurr;
+                u32 availableCached = pCachedEnd - pCachedStart;
+                return FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
+            }
+            void ArchiveFontBase::CachedStreamReader::copyBugged(void* dst, u32 len) {
+                u32 cachedLen = pCachedEnd - pCachedStart;
+                if (len <= cachedLen) {
+                    memmove(dst, pCachedStart, len);
+                    pCachedStart += len;
+                } else {
+                    memmove(dst, pCachedStart, cachedLen);
+                    // @bug Should be dst + cachedLen
+                    memmove(dst, FORCE_REACCESS_4(pDataCurr, u8*), len - cachedLen);
+                    pCachedStart = pCachedEnd;
+                    pDataCurr += len - cachedLen;
+                }
+            }
+            void ArchiveFontBase::CachedStreamReader::memcpyToWork(ArchiveFontBase::ConstructContext& ctx, u32 copyLen) {
+                u32 cachedLen = amtAvailableCached();
+                u8* dst = FORCE_REACCESS_4(ctx.pWorkCurr, u8*);
+                if (cachedLen >= copyLen) {
+                    memcpy(dst, pCachedStart, copyLen);
+                    pCachedStart = FORCE_REACCESS_4(pCachedStart, u8*) + copyLen;
+                } else {
+                    u32 dataLen = copyLen - cachedLen;
+                    memcpy(dst, pCachedStart, cachedLen);
+                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
+                    pCachedStart = FORCE_REACCESS_4(pCachedEnd, u8*);
+                    pDataCurr = pDataCurr + dataLen;
+                }
+            }
+            void ArchiveFontBase::CachedStreamReader::copyMemmove(void* dst, u32 len) {
+                u32 cachedLen = pCachedEnd - pCachedStart;
+                if (len <= cachedLen) {
+                    memmove(dst, pCachedStart, len);
+                    pCachedStart += len;
+                } else {
+                    memmove(dst, pCachedStart, cachedLen);
+                    memmove((u8*)dst + cachedLen, pDataCurr, len - cachedLen);
+                    pCachedStart = pCachedEnd;
+                    pDataCurr += len - cachedLen;
+                }
+            }
+            void ArchiveFontBase::CachedStreamReader::Init() {
+                pDataStart = NULL;
+                pDataCurr = NULL;
+                pDataEnd = NULL;
+
+                pCachedBase = NULL;
+                pCachedStart = NULL;
+                pCachedEnd = NULL;
+
+                unk_0x18 = 0;
+            }
+            void ArchiveFontBase::CachedStreamReader::Attach(void* data, u32 dataLen) {
+                pDataStart = (u8*)data;
+                pDataCurr = (u8*)data;
+                pDataEnd = (u8*)data + dataLen;
+            }
+            bool ArchiveFontBase::CachedStreamReader::RequestData(ArchiveFontBase::ConstructContext& ctx, u32 offset) {
+                size_t available = amtAvailableRevLoadOrder();
+                if (available == 0) {
+                    pCachedBase = NULL;
+                    pCachedStart = NULL;
+                    pCachedEnd = NULL;
+                    unk_0x18 = 0;
+                } else {
+                    if (ctx.remWorkSpace() < (offset << 1))
+                        return false;
+                    size_t cachedLen = amtAvailableCached();
+
+                    u8* dst = FORCE_REACCESS_4(ctx.pWorkCurr, u8*) + offset;
+                    if (cachedLen >= available) {
+                        memmove(dst, pCachedStart, available);
+                        pCachedStart += available;
+                    } else {
+                        u32 dataLen = available - cachedLen;
+                        memmove(dst, pCachedStart, cachedLen);
+                        memmove(dst + cachedLen, pDataCurr, dataLen);
+                        pCachedStart = pCachedEnd;
+                        pDataCurr = FORCE_REACCESS_4(pDataCurr, u8*) + dataLen;
+                    }
+                    pCachedBase = dst;
+                    pCachedStart = dst;
+                    pCachedEnd = dst + available;
+                    unk_0x18 = offset;
+                }
+                return true;
+            }
+
+            u32 ArchiveFontBase::ConstructContext::remWorkSpace() {
+                return FORCE_REACCESS_4(pWorkEnd, u8*) - FORCE_REACCESS_4(pWorkCurr, u8*);
+            }
+            void ArchiveFontBase::ConstructContext::updateDataOffset(CachedStreamReader& reader) {
+                mDataOffset += (u32)(reader.pDataCurr - reader.pDataStart) + (reader.pCachedStart - reader.pCachedBase);
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructContext::requestNewData(CachedStreamReader& reader, u32 amt) {
+                updateDataOffset(reader);
+                bool requestSucceeded = reader.RequestData(*this, amt);
+                if (requestSucceeded)
+                    return CONSTRUCT_STATE_DATA_REQUESTED;
+                else
+                    return CONSTRUCT_STATE_FATAL_ERR;
+            }
+
+            ArchiveFontBase::ArchiveFontBase() : pSheetOffsets(NULL) {
+            }
+            ArchiveFontBase::~ArchiveFontBase() {
+            }
+
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFileHeader(ConstructContext& ctx, CachedStreamReader& reader) {
+                int iVar1;
+                void* cacheStart;
+                u32 cachedLen;
+                void* fileHdrDest;
+                if (reader.amtAvailable() < sizeof(BinaryFileHeader)) {
+                    ctx.updateDataOffset(reader);
+                    bool requestSucceeded = reader.RequestData(ctx, sizeof(BinaryFileHeader));
+                    if (requestSucceeded)
+                        return CONSTRUCT_STATE_DATA_REQUESTED;
+                    else
+                        return CONSTRUCT_STATE_FATAL_ERR;
+                }
+                if (ctx.remWorkSpace() < sizeof(BinaryFileHeader))
+                    return CONSTRUCT_STATE_FATAL_ERR;
+                reader.memcpyToWork(ctx, sizeof(BinaryFileHeader));
+                ctx.mNextCmd = CONSTRUCT_CMD_DISPATCH;
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFINF(ConstructContext& ctx) {
+                u32 finfInnerSize = ctx.mNextBlockLen - 8;
+                if (ctx.remWorkSpace() < finfInnerSize)
+                    return CONSTRUCT_STATE_FATAL_ERR;
+
+                ctx.mNextCmdParam = finfInnerSize;
+                ctx.pFinf = (FontInformation*)FORCE_REACCESS_4(ctx.pWorkCurr, u8*);
+
+                ctx.mNextCmd = CONSTRUCT_CMD_COPY;
+                ctx.mQueuedCmd = CONSTRUCT_CMD_DISPATCH;
+                return CONSTRUCT_STATE_WORKING;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpCopy(ConstructContext& ctx, CachedStreamReader& reader) {
+                ConstructState newState;
+                u32 copySize = reader.pDataEnd - reader.pDataCurr;
+                // u32 totalCopySize = ctx.mNextCmdParam;
+                if (copySize <= ctx.mNextCmdParam)
+                    ;
+                else
+                    copySize = ctx.mNextCmdParam;
+                memcpy(ctx.pWorkCurr, reader.pDataCurr, copySize);
+                reader.pDataCurr += copySize;
+                ctx.pWorkCurr += copySize;
+                if (copySize <= ctx.mNextCmdParam)
+                    ;
+                else
+                    copySize = FORCE_REACCESS_4(ctx.mNextCmdParam, u32);
+                u32 remaining = ctx.mNextCmdParam - copySize;
+                ctx.mNextCmdParam = remaining;
+                if (remaining == 0) {
+                    ctx.mNextCmd = ctx.mQueuedCmd;
+                    newState = CONSTRUCT_STATE_WORKING;
+                } else {
+                    return ctx.requestNewData(reader, remaining);
+                }
+                return newState;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpSkip(ConstructContext& ctx, CachedStreamReader& reader) {
+                ConstructState newState;
+                register u32 copySize = ctx.mNextCmdParam;
+                register u32 available = reader.amtAvailable();
+                if (available < ctx.mNextCmdParam)
+                    copySize = available;
+
+                available = reader.amtAvailableCached();
+                if (copySize < available) {
+                    reader.pCachedStart += copySize;
+                } else {
+                    reader.pDataCurr += copySize - available;
+                    reader.pCachedStart = reader.pCachedEnd;
+                }
+
+                if (ctx.mNextCmdParam < copySize)
+                    copySize = ctx.mNextCmdParam;
+                register u32 remaining = ctx.mNextCmdParam - copySize;
+                if (remaining == 0) {
+                    ctx.mNextCmd = ctx.mQueuedCmd;
+                    newState = CONSTRUCT_STATE_WORKING;
+                } else {
+                    return ctx.requestNewData(reader, remaining);
+                }
+                return newState;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpExpand(ConstructContext& ctx, CachedStreamReader& reader) {
+                ConstructState nextState;
+                // register u32 available = reader.pDataEnd - reader.pDataCurr;
+                // register u32 availableCached = reader.pCachedEnd - reader.pCachedStart;
+                // available += availableCached;
+                register u32 available = reader.amtAvailableRevLoadOrder();
+
+                register u32 cmprSize;
+                {
+                    if (ctx.mNextCmdParam > available)
+                        cmprSize = available;
+                    else
+                        cmprSize = ctx.mNextCmdParam;
+                }
+
+                // u8* cmprBuf = reader.advanceData(cmprSize);
+                CXReadUncompHuffman(ctx.pHuffmanCtx, reader.advanceData(cmprSize), cmprSize);
+
+                u32 nextCmdParam = ctx.mNextCmdParam;
+                if (cmprSize > nextCmdParam)
+                    cmprSize = nextCmdParam;
+                register u32 remaining = FORCE_REACCESS_4(ctx.mNextCmdParam, u32) - cmprSize;
+                ctx.mNextCmdParam = remaining;
+
+                if (remaining == 0) {
+                    ctx.mNextCmd = ctx.mQueuedCmd;
+                    nextState = CONSTRUCT_STATE_WORKING;
+                } else {
+                    return ctx.requestNewData(reader, remaining);
+                }
+                return nextState;
+            }
+            ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpFatalErr(ConstructContext& ctx) {
+                ctx.mNextCmd = CONSTRUCT_CMD_FATAL_ERR;
+                return CONSTRUCT_STATE_FATAL_ERR;
+            }
+        }  // namespace detail
+    }  // namespace ut
+}  // namespace nw4r

--- a/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
@@ -145,11 +145,7 @@ namespace nw4r {
                 u8* workCurr;
                 u8* dst;
 
-                u32 availableData, availableCached;
-
-                availableData = pDataEnd - pDataCurr;
-                availableCached = pCachedEnd - pCachedStart;
-                available = FORCE_REACCESS_4(availableData, u32) + FORCE_REACCESS_4(availableCached, u32);
+                available = amtAvailableData() + amtAvailableCached();
                 if (available == 0) {
                     pCachedBase = NULL;
                     pCachedStart = NULL;
@@ -173,7 +169,7 @@ namespace nw4r {
                         memmove(dst, cachedStart, cachedLen);
                         memmove(dst + cachedLen, pDataCurr, dataLen);
                         pCachedStart = pCachedEnd;
-                        pDataCurr = FORCE_REACCESS_4(pDataCurr, u8*) + dataLen;
+                        pDataCurr += dataLen;
                     }
                     pCachedBase = dst;
                     pCachedStart = dst;

--- a/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
@@ -11,6 +11,10 @@
 namespace nw4r {
     namespace ut {
         namespace detail {
+#define ENSURE_HAS_SIZE(_ctx, _reader, _size)                                                                                                        \
+    if (((_reader)->pDataEnd - (_reader)->pDataCurr) + ((_reader)->pCachedEnd - (_reader)->pCachedStart) < _size)                                    \
+        return (_ctx)->requestNewData((_reader), _size);
+
 #define GLYPH_INDEX_NOT_FOUND 0xFFFF
             typedef union {
                 u16 formatRaw;
@@ -25,10 +29,14 @@ namespace nw4r {
                 return (pDataCurr - pDataStart) + (pCachedStart - pCachedBase);
             }
 
-            size_t ArchiveFontBase::CachedStreamReader::amtAvailableRevLoadOrder() {
-                u32 availableData = amtAvailableData();
-                u32 availableCached = amtAvailableCached();
-                return availableData + FORCE_REACCESS_4(availableCached, u32);
+            // size_t ArchiveFontBase::CachedStreamReader::amtAvailableRevLoadOrder() {
+            //     u32 availableData = amtAvailableData();
+            //     u32 availableCached = amtAvailableCached();
+            //     return availableData + FORCE_REACCESS_4(availableCached, u32);
+            // }
+
+            inline size_t getAdvanceSize(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBase::CachedStreamReader* reader) {
+                return ut::Min(ctx->mNextCmdParam, reader->amtAvailable());
             }
 
             void ArchiveFontBase::CachedStreamReader::memcpyToBufRev(void* _dst, u32 copyLen) {
@@ -54,29 +62,6 @@ namespace nw4r {
                     pDataCurr = pDataCurr + dataLen;
                 }
             }
-            void ArchiveFontBase::CachedStreamReader::memcpyToBufReaccess(void* _dst, u32 copyLen) {
-                u32 cachedLen;
-                u8* dst;
-                u32 dataLen;
-
-                u8* cachedStart;
-                u8* cachedEnd;
-
-                dst = (u8*)_dst;
-                cachedStart = FORCE_REACCESS_4(pCachedStart, u8*);
-                cachedEnd = FORCE_REACCESS_4(pCachedEnd, u8*);
-                cachedLen = cachedEnd - cachedStart;
-                if (cachedLen >= copyLen) {
-                    memcpy(dst, cachedStart, copyLen);
-                    pCachedStart += copyLen;
-                } else {
-                    dataLen = copyLen - cachedLen;
-                    memcpy(dst, cachedStart, cachedLen);
-                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
-                    pCachedStart = pCachedEnd;
-                    pDataCurr += dataLen;
-                }
-            }
             void ArchiveFontBase::CachedStreamReader::memcpyToBuf(void* _dst, u32 copyLen) {
                 u32 cachedLen;
                 u8* dst;
@@ -86,15 +71,13 @@ namespace nw4r {
                 u8* cachedEnd;
 
                 dst = (u8*)_dst;
-                cachedStart = pCachedStart;
-                cachedEnd = pCachedEnd;
-                cachedLen = cachedEnd - cachedStart;
+                cachedLen = amtAvailableCached();
                 if (cachedLen >= copyLen) {
-                    memcpy(dst, cachedStart, copyLen);
+                    memcpy(dst, pCachedStart, copyLen);
                     pCachedStart += copyLen;
                 } else {
                     dataLen = copyLen - cachedLen;
-                    memcpy(dst, cachedStart, cachedLen);
+                    memcpy(dst, pCachedStart, cachedLen);
                     memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
                     pCachedStart = pCachedEnd;
                     pDataCurr += dataLen;
@@ -140,9 +123,6 @@ namespace nw4r {
                 size_t cachedLen;
                 size_t available;
 
-                u8* cachedEnd;
-                u8* cachedStart;
-                u8* workCurr;
                 u8* dst;
 
                 available = amtAvailableData() + amtAvailableCached();
@@ -154,19 +134,16 @@ namespace nw4r {
                 } else {
                     if (ctx->remWorkSpace() < (offset << 1))
                         return false;
-                    cachedStart = FORCE_REACCESS_4(pCachedStart, u8*);
-                    cachedEnd = FORCE_REACCESS_4(pCachedEnd, u8*);
-                    workCurr = FORCE_REACCESS_4(ctx->pWorkCurr, u8*);
-                    // return ;
-                    cachedLen = cachedEnd - cachedStart;
 
-                    dst = workCurr + offset;
+                    dst = ctx->pWorkCurr + offset;
+                    cachedLen = pCachedEnd - pCachedStart;
+
                     if (cachedLen >= available) {
-                        memmove(dst, cachedStart, available);
+                        memmove(dst, pCachedStart, available);
                         pCachedStart += available;
                     } else {
                         dataLen = available - cachedLen;
-                        memmove(dst, cachedStart, cachedLen);
+                        memmove(dst, pCachedStart, cachedLen);
                         memmove(dst + cachedLen, pDataCurr, dataLen);
                         pCachedStart = pCachedEnd;
                         pDataCurr += dataLen;
@@ -184,7 +161,7 @@ namespace nw4r {
                 return pWorkEnd - pWorkCurr;
             }
             void ArchiveFontBase::ConstructContext::updateDataOffset(CachedStreamReader* reader) {
-                mDataOffset += (u32)(reader->pDataCurr - reader->pDataStart) + (reader->pCachedStart - reader->pCachedBase);
+                mDataOffset += (reader->pDataCurr - reader->pDataStart) + (reader->pCachedStart - reader->pCachedBase);
             }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructContext::requestNewData(CachedStreamReader* reader, u32 amt) {
                 updateDataOffset(reader);
@@ -330,10 +307,9 @@ namespace nw4r {
 
                 if (ctx->mBlocksParsed >= ctx->mTotalBlocks)
                     return CONSTRUCT_STATE_DONE;
-                if (reader->amtAvailable() < sizeof(BinaryBlockHeader))
-                    return ctx->requestNewData(reader, sizeof(BinaryBlockHeader));
 
-                reader->memcpyToBufReaccess(&ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
+                ENSURE_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
+                reader->memcpyToBuf(&ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
                 switch (ctx->mNextBlockHdr.kind) {
                     case SIGNATURE_GLYPH_GROUPS:
                         ctx->mNextCmd = CONSTRUCT_CMD_ANALYZE_GLGR;
@@ -359,12 +335,12 @@ namespace nw4r {
                 return CONSTRUCT_STATE_WORKING;
             }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFileHeader(ConstructContext* ctx, CachedStreamReader* reader) {
-                if (reader->amtAvailable() < sizeof(BinaryFileHeader))
+                if ((reader->pDataEnd - reader->pDataCurr) + (reader->pCachedEnd - reader->pCachedStart) < sizeof(BinaryFileHeader))
                     return ctx->requestNewData(reader, sizeof(BinaryFileHeader));
                 if (ctx->remWorkSpace() < sizeof(BinaryFileHeader))
                     return CONSTRUCT_STATE_FATAL_ERR;
 
-                reader->memcpyToBufReaccess(ctx->pWorkCurr, sizeof(BinaryFileHeader));
+                reader->memcpyToBuf(ctx->pWorkCurr, sizeof(BinaryFileHeader));
                 ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
                 return CONSTRUCT_STATE_WORKING;
             }
@@ -384,12 +360,12 @@ namespace nw4r {
                 glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
                 reader->memcpyToBuf(glgr, glgrInnerLen);
             }
-            inline void updateSheetFlags(const void* glgrHdr, u32 groupIdx, u16* sheetOffsets, u32 sheetFlagsSize, const u32* bitBlocksPtr) {
+            inline void updateSheetFlags(const void* glgrHdr, u32 groupIdx, u16* sheetOffsets, u32 flagsStep, const u32* sheetFlags) {
                 const GlyphGroups* glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
                 for (int sheetI = 0; sheetI < glgr->sheetCount; sheetI++) {
-                    u32 groupBitIdx = sheetI + groupIdx * sheetFlagsSize * 8;
+                    u32 groupBitIdx = sheetI + groupIdx * flagsStep * 8;
 
-                    const u32* bitBlockPtr = bitBlocksPtr + (groupBitIdx & ~0x1f) / 32;
+                    const u32* bitBlockPtr = sheetFlags + (groupBitIdx & ~0x1f) / 32;
                     u32 bitBlock = *(u32*)bitBlockPtr;
                     if (((bitBlock << (groupBitIdx & 0x1f)) & 0x80000000) != 0)
                         sheetOffsets[sheetI] = 1;
@@ -431,18 +407,101 @@ namespace nw4r {
                 memmove(sheetOffsets, sheetOffsetsScratch, scratchSize);
                 ctx->pSheetOffsets = (u16*)sheetOffsets;
             }
+            inline ArchiveFontBase::ConstructState ConstructOpAnalyzeGLGRInner(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBinaryLayout* font,
+                                                                               HeaderedGlyphGroups* pGlgr, void* glgrEnd) {
+                u32 fontSizeToEndOfGlgr;
+                u32 remWorkSpace;
+
+                u16 dataBlockCount;
+                u16 sheetGlyphCount;
+                u16 countSheet;
+
+                u32 stepSheetFlags;
+                u32 flagsSheetsOff;
+                const u32* flagsSheets;
+
+                u32 sheetOffsetsSize;
+                u16* sheetOffsetsScratch;
+
+                u32 sheetOffsetsScratchSize;
+                u8* workCurr;
+                u8* workEnd;
+                // u8* calculatedWorkEnd;
+                u32 requiredSpace;
+
+                // workCurr = ctx->pWorkCurr;
+                // workEnd = ctx->pWorkEnd;
+
+                fontSizeToEndOfGlgr = (u8*)glgrEnd - (u8*)font;
+                remWorkSpace = ctx->remWorkSpace();
+
+                countSheet = font->glgr.inner.sheetCount;            // 0x20
+                sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
+                dataBlockCount = font->hdr.dataBlocks;               // 0x0E
+
+                sheetOffsetsSize = detail::CalcSizeSheetOffsets(countSheet);
+                sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u32)font + remWorkSpace - sheetOffsetsSize), 2);
+                requiredSpace = fontSizeToEndOfGlgr + sheetOffsetsSize;
+
+                stepSheetFlags = detail::CalcSizeFlagSet(countSheet);
+
+                flagsSheetsOff = detail::CalcOffsetSheetFlags(font->glgr.inner.nameCount, countSheet, font->glgr.inner.smthCount_0x0a,
+                                                              font->glgr.inner.smthCount_0x0c);
+                flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
+
+                if (remWorkSpace < requiredSpace)
+                    return ArchiveFontBase::CONSTRUCT_STATE_FATAL_ERR;
+
+                // Clear sheet offsets scratch
+                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++)
+                //     sheetOffsetsScratch[i] = 0;
+
+                // for (s32 i = 0; i < pGlgr->inner.nameCount; i++) {
+                //     // const char* includedGroups = ctx->pIncludedGroups;
+                //     u16 offset = pGlgr->inner.nameOffsets[i];
+                //     const char* name = (char*)((u8*)font + offset);
+                //     if (*ctx->pIncludedGroups != 0)
+                //         if (!ArchiveFontBase::IncludeName(ctx->pIncludedGroups, name))
+                //             continue;
+
+                //     updateSheetFlags(pGlgr, i, sheetOffsetsScratch, stepSheetFlags, flagsSheets);
+                // }
+                setSheetOffsetBooleans(ctx, pGlgr, font, sheetOffsetsScratch, flagsSheets, stepSheetFlags);
+
+                // u16 glyphIdxOffset = 0;
+                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++) {
+                //     if (sheetOffsetsScratch[i] == 1) {
+                //         sheetOffsetsScratch[i] = glyphIdxOffset;
+                //     } else {
+                //         sheetOffsetsScratch[i] = -1;
+                //         glyphIdxOffset += pGlgr->inner.sheetGlyphCount;
+                //     }
+                // }
+                convertSheetOffsetBooleansToOffsets(pGlgr, sheetOffsetsScratch);
+
+                sheetOffsetsScratchSize = (u32)countSheet << 1;
+                sheetOffsetsScratchSize += (sheetOffsetsScratchSize >> 31);
+                sheetOffsetsScratchSize &= ~1;
+                copyFlagOffsets(ctx, sheetOffsetsScratch, sheetOffsetsSize, sheetOffsetsScratchSize);
+
+                ctx->mSheetCount = countSheet;
+                ctx->mGlyphsPerSheet = sheetGlyphCount;
+                ctx->mTotalBlocks = dataBlockCount;
+                ctx->mNextCmd = ArchiveFontBase::CONSTRUCT_CMD_DISPATCH;
+
+                return ArchiveFontBase::CONSTRUCT_STATE_WORKING;
+            }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeGLGR(ConstructContext* ctx, CachedStreamReader* reader) {
+                u32 glgrInnerLen;
+                HeaderedGlyphGroups* pGlgr;
                 ArchiveFontBinaryLayout* font;
-                HeaderedGlyphGroups* glgrHdr;
                 u8* glgrEnd;
 
                 u32 expectedMaxSize;
-                u32 glgrFullLen, glgrInnerLen;
 
                 font = (ArchiveFontBinaryLayout*)ctx->pWorkCurr;
 
-                glgrFullLen = ctx->mNextBlockHdr.size;
-                glgrInnerLen = glgrFullLen - sizeof(BinaryBlockHeader);
+                glgrInnerLen = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
 
                 // Check for RFNA
                 if (font->hdr.signature != SIGNATURE_FONT_ARCHIVE)
@@ -450,76 +509,113 @@ namespace nw4r {
 
                 // Check that there's enough data available, and the space to
                 // put that data
-                if (reader->amtAvailable() < glgrInnerLen)
-                    return ctx->requestNewData(reader, glgrInnerLen);
+                ENSURE_HAS_SIZE(ctx, reader, glgrInnerLen);
                 if (ctx->remWorkSpace() < glgrInnerLen)
                     return CONSTRUCT_STATE_FATAL_ERR;
 
-                expectedMaxSize = glgrFullLen + sizeof(BinaryFileHeader);
+                expectedMaxSize = ctx->mNextBlockHdr.size + sizeof(BinaryFileHeader);
 
                 // Copy the glgr to work
                 {
-                    glgrHdr = &font->glgr;
-                    glgrEnd = (u8*)glgrHdr + (u32)ctx->mNextBlockHdr.size;
+                    pGlgr = &font->glgr;
+                    glgrEnd = (u8*)pGlgr + (u32)ctx->mNextBlockHdr.size;
 
-                    memcpy(glgrHdr, &ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
-                    reader->memcpyToBuf(&glgrHdr->inner, glgrInnerLen);
+                    memcpy(pGlgr, &ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
+                    reader->memcpyToBuf(&pGlgr->inner, glgrInnerLen);
                 }
 
                 if (!ArchiveFontBase::IsValidResource(font, expectedMaxSize))
                     return CONSTRUCT_STATE_FATAL_ERR;
 
                 // Before here is fine (other than regswaps)
+                pGlgr = &font->glgr;
+                // u16 sheetGlyphCount = FORCE_REACCESS_2(font->glgr.inner.sheetGlyphCount, u16);  // 0x1C
+                // u16 dataBlockCount = FORCE_REACCESS_2(font->hdr.dataBlocks, u16);               // 0x0E
+                // FORCE_REACCESS_2(font->glgr.inner.sheetCount, u16);
+                // return ConstructOpAnalyzeGLGRInner(ctx, font, pGlgr, glgrEnd);
 
-                // return analyzeGlgrInner(ctx, font, glgrEnd);
-                u8* workCurr;
                 u32 fontSizeToEndOfGlgr;
-                u16 sheetGlyphCount, dataBlockCount;
-                u16 countNames, countSheets;
-                u32 sheetFlagsSize, sheetOffsetsSize;
-                u32* sheetFlagsPtr;
                 u32 remWorkSpace;
+
+                u16 countSheet;
+                u16 sheetGlyphCount, dataBlockCount;
+
+                u32 stepSheetFlags;
+                u32 flagsSheetsOff;
+                const u32* flagsSheets;
+
+                u32 sheetOffsetsSize;
                 u16* sheetOffsetsScratch;
-                u32 workSizeNeeded;
+
                 u32 sheetOffsetsScratchSize;
 
-                workCurr = ctx->pWorkCurr;
-                glgrHdr = &font->glgr;
+                remWorkSpace = ctx->remWorkSpace();
 
                 fontSizeToEndOfGlgr = glgrEnd - (u8*)font;
 
-                sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
                 dataBlockCount = font->hdr.dataBlocks;               // 0x0E
+                sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
+                // countName = font->glgr.inner.nameCount;
+                countSheet = font->glgr.inner.sheetCount;
+                // count0A = font->glgr.inner.smthCount_0x0a;
+                // count0C = font->glgr.inner.smthCount_0x0c;
 
-                countNames = font->glgr.inner.nameCount;    // 0x1E
-                countSheets = font->glgr.inner.sheetCount;  // 0x20
-
-                // sheetFlagsSize, sheetOffsetsSize, sheetFlagsPtr
-                {
-                    sheetFlagsSize = CalcSizeSheetFlagSet(countSheets);
-                    sheetOffsetsSize = CalcSizeSheetOffsets(countSheets);
-                    sheetFlagsPtr =
-                        (u32*)(CalcOffsetSheetFlags(countNames, countSheets, font->glgr.inner.smthCount_0x0a, font->glgr.inner.smthCount_0x0c) +
-                               (u8*)font);
-                }
-                remWorkSpace = ctx->pWorkEnd - workCurr;
-
+                sheetOffsetsSize = ROUNDUP(countSheet * sizeof(u16), 4);
                 sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u8*)font + remWorkSpace) - sheetOffsetsSize, 2);
 
-                workSizeNeeded = fontSizeToEndOfGlgr + sheetOffsetsSize;
-                if (remWorkSpace < workSizeNeeded)
+                stepSheetFlags = detail::CalcSizeFlagSet(countSheet);
+
+                // u32 nameOffSize = font->glgr.inner.nameCount * sizeof(u16);
+                // u32 dataSheetSize = countSheet * sizeof(u32);
+                // u32 data0ASize = font->glgr.inner.smthCount_0x0a * sizeof(u32);
+                // u32 data0CSize = font->glgr.inner.smthCount_0x0c * sizeof(u32);
+
+                // dataSheetsOff = ROUNDUP(offsetof(ArchiveFontBinaryLayout, glgr.inner.nameOffsets) + nameOffSize, 4);
+                // data0AOff = ROUNDUP(dataSheetsOff + dataSheetSize, 4);
+                // data0COff = ROUNDUP(data0AOff + data0ASize, 4);
+
+                // flagsSheetsOff = ROUNDUP(data0COff + data0CSize, 4);
+                // flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
+                flagsSheetsOff = detail::CalcOffsetSheetFlags(font->glgr.inner.nameCount, countSheet, font->glgr.inner.smthCount_0x0a,
+                                                              font->glgr.inner.smthCount_0x0c);
+                flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
+
+                if (remWorkSpace < fontSizeToEndOfGlgr + sheetOffsetsSize)
                     return CONSTRUCT_STATE_FATAL_ERR;
 
-                setSheetOffsetBooleans(ctx, glgrHdr, font, sheetOffsetsScratch, sheetFlagsPtr, sheetFlagsSize);
+                // Clear sheet offsets scratch
+                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++)
+                //     sheetOffsetsScratch[i] = 0;
 
-                convertSheetOffsetBooleansToOffsets(glgrHdr, sheetOffsetsScratch);
+                // for (s32 i = 0; i < pGlgr->inner.nameCount; i++) {
+                //     // const char* includedGroups = ctx->pIncludedGroups;
+                //     u16 offset = pGlgr->inner.nameOffsets[i];
+                //     const char* name = (char*)((u8*)font + offset);
+                //     if (*ctx->pIncludedGroups != 0)
+                //         if (!ArchiveFontBase::IncludeName(ctx->pIncludedGroups, name))
+                //             continue;
 
-                sheetOffsetsScratchSize = (u32)countSheets << 1;
+                //     updateSheetFlags(pGlgr, i, sheetOffsetsScratch, stepSheetFlags, flagsSheets);
+                // }
+                setSheetOffsetBooleans(ctx, pGlgr, font, sheetOffsetsScratch, flagsSheets, stepSheetFlags);
+
+                // u16 glyphIdxOffset = 0;
+                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++) {
+                //     if (sheetOffsetsScratch[i] == 1) {
+                //         sheetOffsetsScratch[i] = glyphIdxOffset;
+                //     } else {
+                //         sheetOffsetsScratch[i] = -1;
+                //         glyphIdxOffset += pGlgr->inner.sheetGlyphCount;
+                //     }
+                // }
+                convertSheetOffsetBooleansToOffsets(pGlgr, sheetOffsetsScratch);
+
+                sheetOffsetsScratchSize = (u32)countSheet << 1;
                 sheetOffsetsScratchSize += (sheetOffsetsScratchSize >> 31);
                 sheetOffsetsScratchSize &= ~1;
                 copyFlagOffsets(ctx, sheetOffsetsScratch, sheetOffsetsSize, sheetOffsetsScratchSize);
 
-                ctx->mSheetCount = countSheets;
+                ctx->mSheetCount = countSheet;
                 ctx->mGlyphsPerSheet = sheetGlyphCount;
                 ctx->mTotalBlocks = dataBlockCount;
                 ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
@@ -571,13 +667,14 @@ namespace nw4r {
                 FlaggedImageFormat origSheetFormat;
                 u16 sheetsToLoad;
 
-                if (reader->amtAvailable() < sizeof(FontTextureGlyph))
-                    return ctx->requestNewData(reader, sizeof(FontTextureGlyph));
+                ENSURE_HAS_SIZE(ctx, reader, sizeof(FontTextureGlyph));
+                // if (reader->amtAvailable() < sizeof(FontTextureGlyph))
+                //     return ctx->requestNewData(reader, sizeof(FontTextureGlyph));
                 if (ctx->remWorkSpace() < sizeof(FontTextureGlyph))
                     return CONSTRUCT_STATE_FATAL_ERR;
 
                 ctx->pFontInfo->pGlyph = (FontTextureGlyph*)ctx->pWorkCurr;
-                reader->memcpyToBufRev(ctx->pWorkCurr, sizeof(FontTextureGlyph));
+                reader->memcpyToBuf(ctx->pWorkCurr, sizeof(FontTextureGlyph));
                 ctx->pWorkCurr += sizeof(FontTextureGlyph);
 
                 origSheetFormat.formatRaw = ctx->pFontInfo->pGlyph->sheetFormat;
@@ -622,15 +719,8 @@ namespace nw4r {
                     ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
                     return CONSTRUCT_STATE_WORKING;
                 }
-                if (reader->amtAvailable() < 8) {
-                    ctx->updateDataOffset(reader);
-                    bool requestSucceeded = reader->RequestData(ctx, 8);
-                    if (requestSucceeded)
-                        return CONSTRUCT_STATE_DATA_REQUESTED;
-                    else
-                        return CONSTRUCT_STATE_FATAL_ERR;
-                }
-                reader->memcpyToBufReaccess(compressedSizeBuf, 4);
+                ENSURE_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
+                reader->memcpyToBuf(compressedSizeBuf, 4);
                 memcpy(compressedDataHdr, reader->pDataCurr, 4);
                 compressedSize = *(u32*)(u8*)compressedSizeBuf;
 
@@ -663,7 +753,7 @@ namespace nw4r {
             }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpCopy(ConstructContext* ctx, CachedStreamReader* reader) {
                 u32 copySize;
-                copySize = ut::Min(reader->amtAvailableData(), ctx->mNextCmdParam);
+                copySize = ut::Min((u32)(reader->pDataEnd - reader->pDataCurr), ctx->mNextCmdParam);
 
                 memcpy(ctx->pWorkCurr, reader->pDataCurr, copySize);
                 reader->pDataCurr += copySize;
@@ -678,10 +768,10 @@ namespace nw4r {
 
                 u32 skipSize;
 
-                skipSize = ut::Min(ctx->mNextCmdParam, reader->amtAvailable());
+                skipSize = getAdvanceSize(ctx, reader);
 
-                end = FORCE_REACCESS_4(reader->pCachedEnd, u8*);
-                start = FORCE_REACCESS_4(reader->pCachedStart, u8*);
+                end = reader->pCachedEnd;
+                start = reader->pCachedStart;
                 cachedLen = end - start;
                 if (cachedLen > skipSize) {
                     reader->pCachedStart = start + skipSize;
@@ -697,10 +787,10 @@ namespace nw4r {
                 u32 cmprSize;
                 u8* src;
 
-                cmprSize = ut::Min(ctx->mNextCmdParam, reader->amtAvailableRevLoadOrder());
+                cmprSize = getAdvanceSize(ctx, reader);
 
                 src = reader->pDataCurr;
-                reader->pDataCurr += cmprSize;
+                reader->pDataCurr = reader->pDataCurr + cmprSize;
                 CXReadUncompHuffman(ctx->pHuffmanCtx, src, cmprSize);
 
                 return handleAdvanceDry(ctx, reader, cmprSize);

--- a/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
+++ b/libs/NW4R/src/ut/ut_ArchiveFontBase.cpp
@@ -4,16 +4,15 @@
 
 #include <string.h>
 
-// Fakematch enablers
-#define FORCE_REACCESS_2(VAR, T) (T) * (volatile u16*)&VAR
-#define FORCE_REACCESS_4(VAR, T) (T) * (volatile u32*)&VAR
-
 namespace nw4r {
     namespace ut {
         namespace detail {
-#define ENSURE_HAS_SIZE(_ctx, _reader, _size)                                                                                                        \
-    if (((_reader)->pDataEnd - (_reader)->pDataCurr) + ((_reader)->pCachedEnd - (_reader)->pCachedStart) < _size)                                    \
-        return (_ctx)->requestNewData((_reader), _size);
+#define ENSURE_READER_HAS_SIZE(_ctx, _reader, _size)                                                                                                 \
+    if ((_reader)->amtAvailableData() + (_reader)->amtAvailableCached() < (_size))                                                                   \
+        return (_ctx)->requestNewData((_reader), (_size));
+#define ENSURE_WORK_HAS_SIZE(_ctx, _size)                                                                                                            \
+    if ((_ctx)->remWorkSpace() < (_size))                                                                                                            \
+        return CONSTRUCT_STATE_FATAL_ERR;
 
 #define GLYPH_INDEX_NOT_FOUND 0xFFFF
             typedef union {
@@ -25,77 +24,33 @@ namespace nw4r {
             } FlaggedImageFormat;
 
             // CachedStreamReader inlined
-            u32 ArchiveFontBase::CachedStreamReader::getCurrentOffset() {
-                return (pDataCurr - pDataStart) + (pCachedStart - pCachedBase);
-            }
-
-            // size_t ArchiveFontBase::CachedStreamReader::amtAvailableRevLoadOrder() {
-            //     u32 availableData = amtAvailableData();
-            //     u32 availableCached = amtAvailableCached();
-            //     return availableData + FORCE_REACCESS_4(availableCached, u32);
-            // }
-
-            inline size_t getAdvanceSize(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBase::CachedStreamReader* reader) {
-                return ut::Min(ctx->mNextCmdParam, reader->amtAvailable());
-            }
-
-            void ArchiveFontBase::CachedStreamReader::memcpyToBufRev(void* _dst, u32 copyLen) {
-                u32 dataLen;
-                u8* dst;
+            void ArchiveFontBase::CachedStreamReader::memcpyToBuf(void* buf, u32 copyLen) {
                 u32 cachedLen;
+                u8* pBuf;
+                u32 dataLen;
 
-                u8* cachedStart;
-                u8* cachedEnd;
-
-                dst = (u8*)_dst;
-                cachedStart = pCachedStart;
-                cachedEnd = pCachedEnd;
-                cachedLen = cachedEnd - cachedStart;
+                pBuf = (u8*)buf;
+                cachedLen = pCachedEnd - pCachedStart;
                 if (cachedLen >= copyLen) {
-                    memcpy(dst, cachedStart, copyLen);
+                    memcpy(pBuf, pCachedStart, copyLen);
                     pCachedStart += copyLen;
                 } else {
                     dataLen = copyLen - cachedLen;
-                    memcpy(dst, cachedStart, cachedLen);
-                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
-                    pCachedStart = pCachedEnd;
-                    pDataCurr = pDataCurr + dataLen;
-                }
-            }
-            void ArchiveFontBase::CachedStreamReader::memcpyToBuf(void* _dst, u32 copyLen) {
-                u32 cachedLen;
-                u8* dst;
-                u32 dataLen;
-
-                u8* cachedStart;
-                u8* cachedEnd;
-
-                dst = (u8*)_dst;
-                cachedLen = amtAvailableCached();
-                if (cachedLen >= copyLen) {
-                    memcpy(dst, pCachedStart, copyLen);
-                    pCachedStart += copyLen;
-                } else {
-                    dataLen = copyLen - cachedLen;
-                    memcpy(dst, pCachedStart, cachedLen);
-                    memcpy((u8*)dst + cachedLen, pDataCurr, dataLen);
+                    memcpy(pBuf, pCachedStart, cachedLen);
+                    memcpy(pBuf + cachedLen, pDataCurr, dataLen);
                     pCachedStart = pCachedEnd;
                     pDataCurr += dataLen;
                 }
             }
-            void ArchiveFontBase::CachedStreamReader::skipReaccess(u32 skipLen) {
-                u8* start;
+            void ArchiveFontBase::CachedStreamReader::skip(u32 skipLen) {
                 u32 dataLen, cachedLen;
-                u8* end;
 
-                end = FORCE_REACCESS_4(pCachedEnd, u8*);
-                start = FORCE_REACCESS_4(pCachedStart, u8*);
-                cachedLen = end - start;
+                cachedLen = pCachedEnd - pCachedStart;
                 if (cachedLen > skipLen) {
-                    pCachedStart = start + skipLen;
+                    pCachedStart += skipLen;
                 } else {
                     dataLen = skipLen - cachedLen;
-                    pCachedStart = end;
+                    pCachedStart = pCachedEnd;
                     pDataCurr += dataLen;
                 }
             }
@@ -157,14 +112,8 @@ namespace nw4r {
             }
 
             // ConstructContext inlined
-            u32 ArchiveFontBase::ConstructContext::remWorkSpace() const {
-                return pWorkEnd - pWorkCurr;
-            }
-            void ArchiveFontBase::ConstructContext::updateDataOffset(CachedStreamReader* reader) {
-                mDataOffset += (reader->pDataCurr - reader->pDataStart) + (reader->pCachedStart - reader->pCachedBase);
-            }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructContext::requestNewData(CachedStreamReader* reader, u32 amt) {
-                updateDataOffset(reader);
+                mDataOffset = getFullOffset(reader);
                 bool requestSucceeded = reader->RequestData(this, amt);
                 if (requestSucceeded)
                     return CONSTRUCT_STATE_DATA_REQUESTED;
@@ -178,22 +127,15 @@ namespace nw4r {
                         (*sheetsToLoad)++;
                 }
             }
-            u16 ArchiveFontBase::ConstructContext::updateTextureBlockFormat() {
-                FlaggedImageFormat origSheetFormat;
-                origSheetFormat.formatRaw = pFontInfo->pGlyph->sheetFormat;
-                pFontInfo->pGlyph->sheetFormat = origSheetFormat.format;
-                return origSheetFormat.isCmpr;
-            }
-            u32 ArchiveFontBase::ConstructContext::updateTextureBlockPtr() {
-                u32 imgDataOffset;
-                imgDataOffset = (u32)pFontInfo->pGlyph->sheetImage;
-                u8* paddedWork = (u8*)(((u32)pWorkCurr + 0x1f) & (~0x1f));
-                pWorkCurr = paddedWork;
+            // u32 ArchiveFontBase::ConstructContext::updateTextureBlockPtr() {
+            //     u32 imgDataOffset;
+            //     imgDataOffset = (u32)pFontInfo->pGlyph->sheetImage;
 
-                pFontInfo->pGlyph->sheetImage = paddedWork;
+            //     pWorkCurr = (u8*)ROUNDUP((u32)pWorkCurr, 0x20);
+            //     pFontInfo->pGlyph->sheetImage = pWorkCurr;
 
-                return imgDataOffset;
-            }
+            //     return imgDataOffset;
+            // }
 
             // ArchiveFontBase retained
             ArchiveFontBase::ArchiveFontBase() : pSheetOffsets(NULL) {
@@ -308,7 +250,7 @@ namespace nw4r {
                 if (ctx->mBlocksParsed >= ctx->mTotalBlocks)
                     return CONSTRUCT_STATE_DONE;
 
-                ENSURE_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
+                ENSURE_READER_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
                 reader->memcpyToBuf(&ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
                 switch (ctx->mNextBlockHdr.kind) {
                     case SIGNATURE_GLYPH_GROUPS:
@@ -335,31 +277,14 @@ namespace nw4r {
                 return CONSTRUCT_STATE_WORKING;
             }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeFileHeader(ConstructContext* ctx, CachedStreamReader* reader) {
-                if ((reader->pDataEnd - reader->pDataCurr) + (reader->pCachedEnd - reader->pCachedStart) < sizeof(BinaryFileHeader))
-                    return ctx->requestNewData(reader, sizeof(BinaryFileHeader));
-                if (ctx->remWorkSpace() < sizeof(BinaryFileHeader))
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_READER_HAS_SIZE(ctx, reader, sizeof(BinaryFileHeader));
+                ENSURE_WORK_HAS_SIZE(ctx, sizeof(BinaryFileHeader));
 
                 reader->memcpyToBuf(ctx->pWorkCurr, sizeof(BinaryFileHeader));
                 ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
                 return CONSTRUCT_STATE_WORKING;
             }
 
-            inline void copyGlgr(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBase::CachedStreamReader* reader, u32 glgrInnerLen) {
-                BinaryFileHeader* hdr;
-                BinaryBlockHeader* glgrHdr;
-                GlyphGroups* glgr;
-
-                hdr = (BinaryFileHeader*)ctx->pWorkCurr;
-
-                // Copy the glgr block header to work
-                glgrHdr = (BinaryBlockHeader*)((u8*)hdr + sizeof(BinaryFileHeader));
-                memcpy(glgrHdr, &ctx->mNextBlockHdr, sizeof(BinaryBlockHeader));
-
-                // Copy the glgr data to work
-                glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
-                reader->memcpyToBuf(glgr, glgrInnerLen);
-            }
             inline void updateSheetFlags(const void* glgrHdr, u32 groupIdx, u16* sheetOffsets, u32 flagsStep, const u32* sheetFlags) {
                 const GlyphGroups* glgr = (GlyphGroups*)((u8*)glgrHdr + sizeof(BinaryBlockHeader));
                 for (int sheetI = 0; sheetI < glgr->sheetCount; sheetI++) {
@@ -407,90 +332,11 @@ namespace nw4r {
                 memmove(sheetOffsets, sheetOffsetsScratch, scratchSize);
                 ctx->pSheetOffsets = (u16*)sheetOffsets;
             }
-            inline ArchiveFontBase::ConstructState ConstructOpAnalyzeGLGRInner(ArchiveFontBase::ConstructContext* ctx, ArchiveFontBinaryLayout* font,
-                                                                               HeaderedGlyphGroups* pGlgr, void* glgrEnd) {
-                u32 fontSizeToEndOfGlgr;
-                u32 remWorkSpace;
-
-                u16 dataBlockCount;
-                u16 sheetGlyphCount;
-                u16 countSheet;
-
-                u32 stepSheetFlags;
-                u32 flagsSheetsOff;
-                const u32* flagsSheets;
-
-                u32 sheetOffsetsSize;
-                u16* sheetOffsetsScratch;
-
-                u32 sheetOffsetsScratchSize;
-                u8* workCurr;
-                u8* workEnd;
-                // u8* calculatedWorkEnd;
-                u32 requiredSpace;
-
-                // workCurr = ctx->pWorkCurr;
-                // workEnd = ctx->pWorkEnd;
-
-                fontSizeToEndOfGlgr = (u8*)glgrEnd - (u8*)font;
-                remWorkSpace = ctx->remWorkSpace();
-
-                countSheet = font->glgr.inner.sheetCount;            // 0x20
-                sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
-                dataBlockCount = font->hdr.dataBlocks;               // 0x0E
-
-                sheetOffsetsSize = detail::CalcSizeSheetOffsets(countSheet);
-                sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u32)font + remWorkSpace - sheetOffsetsSize), 2);
-                requiredSpace = fontSizeToEndOfGlgr + sheetOffsetsSize;
-
-                stepSheetFlags = detail::CalcSizeFlagSet(countSheet);
-
-                flagsSheetsOff = detail::CalcOffsetSheetFlags(font->glgr.inner.nameCount, countSheet, font->glgr.inner.smthCount_0x0a,
-                                                              font->glgr.inner.smthCount_0x0c);
-                flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
-
-                if (remWorkSpace < requiredSpace)
-                    return ArchiveFontBase::CONSTRUCT_STATE_FATAL_ERR;
-
-                // Clear sheet offsets scratch
-                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++)
-                //     sheetOffsetsScratch[i] = 0;
-
-                // for (s32 i = 0; i < pGlgr->inner.nameCount; i++) {
-                //     // const char* includedGroups = ctx->pIncludedGroups;
-                //     u16 offset = pGlgr->inner.nameOffsets[i];
-                //     const char* name = (char*)((u8*)font + offset);
-                //     if (*ctx->pIncludedGroups != 0)
-                //         if (!ArchiveFontBase::IncludeName(ctx->pIncludedGroups, name))
-                //             continue;
-
-                //     updateSheetFlags(pGlgr, i, sheetOffsetsScratch, stepSheetFlags, flagsSheets);
-                // }
-                setSheetOffsetBooleans(ctx, pGlgr, font, sheetOffsetsScratch, flagsSheets, stepSheetFlags);
-
-                // u16 glyphIdxOffset = 0;
-                // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++) {
-                //     if (sheetOffsetsScratch[i] == 1) {
-                //         sheetOffsetsScratch[i] = glyphIdxOffset;
-                //     } else {
-                //         sheetOffsetsScratch[i] = -1;
-                //         glyphIdxOffset += pGlgr->inner.sheetGlyphCount;
-                //     }
-                // }
-                convertSheetOffsetBooleansToOffsets(pGlgr, sheetOffsetsScratch);
-
-                sheetOffsetsScratchSize = (u32)countSheet << 1;
-                sheetOffsetsScratchSize += (sheetOffsetsScratchSize >> 31);
-                sheetOffsetsScratchSize &= ~1;
-                copyFlagOffsets(ctx, sheetOffsetsScratch, sheetOffsetsSize, sheetOffsetsScratchSize);
-
-                ctx->mSheetCount = countSheet;
-                ctx->mGlyphsPerSheet = sheetGlyphCount;
-                ctx->mTotalBlocks = dataBlockCount;
-                ctx->mNextCmd = ArchiveFontBase::CONSTRUCT_CMD_DISPATCH;
-
-                return ArchiveFontBase::CONSTRUCT_STATE_WORKING;
-            }
+            // inline u32 getOffsetSize(void* fontData, u32 remWorkSpace, u16 countSheet, u16** sheetOffsetsScratch) {
+            //     u32 sheetOffsetsSize = ROUNDUP(countSheet * sizeof(u16), 4);
+            //     *sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u8*)fontData + remWorkSpace) - sheetOffsetsSize, 2);
+            //     return sheetOffsetsSize;
+            // }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpAnalyzeGLGR(ConstructContext* ctx, CachedStreamReader* reader) {
                 u32 glgrInnerLen;
                 HeaderedGlyphGroups* pGlgr;
@@ -509,9 +355,8 @@ namespace nw4r {
 
                 // Check that there's enough data available, and the space to
                 // put that data
-                ENSURE_HAS_SIZE(ctx, reader, glgrInnerLen);
-                if (ctx->remWorkSpace() < glgrInnerLen)
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_READER_HAS_SIZE(ctx, reader, glgrInnerLen);
+                ENSURE_WORK_HAS_SIZE(ctx, glgrInnerLen);
 
                 expectedMaxSize = ctx->mNextBlockHdr.size + sizeof(BinaryFileHeader);
 
@@ -528,14 +373,12 @@ namespace nw4r {
                     return CONSTRUCT_STATE_FATAL_ERR;
 
                 // Before here is fine (other than regswaps)
-                pGlgr = &font->glgr;
                 // u16 sheetGlyphCount = FORCE_REACCESS_2(font->glgr.inner.sheetGlyphCount, u16);  // 0x1C
                 // u16 dataBlockCount = FORCE_REACCESS_2(font->hdr.dataBlocks, u16);               // 0x0E
                 // FORCE_REACCESS_2(font->glgr.inner.sheetCount, u16);
                 // return ConstructOpAnalyzeGLGRInner(ctx, font, pGlgr, glgrEnd);
 
-                u32 fontSizeToEndOfGlgr;
-                u32 remWorkSpace;
+                // u32 fontSizeToEndOfGlgr;
 
                 u16 countSheet;
                 u16 sheetGlyphCount, dataBlockCount;
@@ -549,39 +392,26 @@ namespace nw4r {
 
                 u32 sheetOffsetsScratchSize;
 
-                remWorkSpace = ctx->remWorkSpace();
-
-                fontSizeToEndOfGlgr = glgrEnd - (u8*)font;
-
                 dataBlockCount = font->hdr.dataBlocks;               // 0x0E
                 sheetGlyphCount = font->glgr.inner.sheetGlyphCount;  // 0x1C
                 // countName = font->glgr.inner.nameCount;
                 countSheet = font->glgr.inner.sheetCount;
                 // count0A = font->glgr.inner.smthCount_0x0a;
                 // count0C = font->glgr.inner.smthCount_0x0c;
-
                 sheetOffsetsSize = ROUNDUP(countSheet * sizeof(u16), 4);
-                sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u8*)font + remWorkSpace) - sheetOffsetsSize, 2);
+                sheetOffsetsScratch = (u16*)ROUNDDOWN((u32)((u8*)font + ctx->remWorkSpace()) - sheetOffsetsSize, 2);
 
                 stepSheetFlags = detail::CalcSizeFlagSet(countSheet);
-
-                // u32 nameOffSize = font->glgr.inner.nameCount * sizeof(u16);
-                // u32 dataSheetSize = countSheet * sizeof(u32);
-                // u32 data0ASize = font->glgr.inner.smthCount_0x0a * sizeof(u32);
-                // u32 data0CSize = font->glgr.inner.smthCount_0x0c * sizeof(u32);
-
-                // dataSheetsOff = ROUNDUP(offsetof(ArchiveFontBinaryLayout, glgr.inner.nameOffsets) + nameOffSize, 4);
-                // data0AOff = ROUNDUP(dataSheetsOff + dataSheetSize, 4);
-                // data0COff = ROUNDUP(data0AOff + data0ASize, 4);
-
-                // flagsSheetsOff = ROUNDUP(data0COff + data0CSize, 4);
-                // flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
                 flagsSheetsOff = detail::CalcOffsetSheetFlags(font->glgr.inner.nameCount, countSheet, font->glgr.inner.smthCount_0x0a,
                                                               font->glgr.inner.smthCount_0x0c);
                 flagsSheets = (const u32*)font + (flagsSheetsOff >> 2);
 
-                if (remWorkSpace < fontSizeToEndOfGlgr + sheetOffsetsSize)
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                // sheetOffsetsSize = ;
+
+                pGlgr = &font->glgr;
+                ENSURE_WORK_HAS_SIZE(ctx, glgrEnd - (u8*)font + sheetOffsetsSize);
+                // if (ctx->pWorkEnd - workCurr < fontSizeToEndOfGlgr + sheetOffsetsSize)
+                //     return CONSTRUCT_STATE_FATAL_ERR;
 
                 // Clear sheet offsets scratch
                 // for (s32 i = 0; i < pGlgr->inner.sheetCount; i++)
@@ -627,8 +457,7 @@ namespace nw4r {
                 u32 innerSize;
 
                 innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
-                if (ctx->remWorkSpace() < innerSize)
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_WORK_HAS_SIZE(ctx, innerSize);
 
                 ctx->pFontInfo = (FontInformation*)ctx->pWorkCurr;
 
@@ -641,8 +470,7 @@ namespace nw4r {
                 ctx->pushCMAP();
 
                 innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
-                if (ctx->remWorkSpace() < innerSize)
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_WORK_HAS_SIZE(ctx, innerSize);
 
                 ctx->enqueueCmds(CONSTRUCT_CMD_COPY, innerSize, CONSTRUCT_CMD_DISPATCH);
                 return CONSTRUCT_STATE_WORKING;
@@ -653,8 +481,7 @@ namespace nw4r {
                 ctx->pushCWDH();
 
                 innerSize = ctx->mNextBlockHdr.size - sizeof(BinaryBlockHeader);
-                if (ctx->remWorkSpace() < innerSize)
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_WORK_HAS_SIZE(ctx, innerSize);
 
                 ctx->enqueueCmds(CONSTRUCT_CMD_COPY, innerSize, CONSTRUCT_CMD_DISPATCH);
                 return CONSTRUCT_STATE_WORKING;
@@ -667,13 +494,11 @@ namespace nw4r {
                 FlaggedImageFormat origSheetFormat;
                 u16 sheetsToLoad;
 
-                ENSURE_HAS_SIZE(ctx, reader, sizeof(FontTextureGlyph));
-                // if (reader->amtAvailable() < sizeof(FontTextureGlyph))
-                //     return ctx->requestNewData(reader, sizeof(FontTextureGlyph));
-                if (ctx->remWorkSpace() < sizeof(FontTextureGlyph))
-                    return CONSTRUCT_STATE_FATAL_ERR;
+                ENSURE_READER_HAS_SIZE(ctx, reader, sizeof(FontTextureGlyph));
+                ENSURE_WORK_HAS_SIZE(ctx, sizeof(FontTextureGlyph));
 
                 ctx->pFontInfo->pGlyph = (FontTextureGlyph*)ctx->pWorkCurr;
+
                 reader->memcpyToBuf(ctx->pWorkCurr, sizeof(FontTextureGlyph));
                 ctx->pWorkCurr += sizeof(FontTextureGlyph);
 
@@ -684,11 +509,14 @@ namespace nw4r {
                 ctx->getNumSheetsToLoad(&sheetsToLoad);
                 ctx->pFontInfo->pGlyph->sheetNum = sheetsToLoad;
 
-                imgDataOffset = ctx->updateTextureBlockPtr();
+                imgDataOffset = (u32)ctx->pFontInfo->pGlyph->sheetImage;
+
+                // Round up work pointer to multiple of 32 bytes
+                ctx->pWorkCurr = (u8*)ROUNDUP((u32)ctx->pWorkCurr, 0x20);
+                ctx->pFontInfo->pGlyph->sheetImage = ctx->pWorkCurr;
 
                 prepCmd = isCmpr ? CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET : CONSTRUCT_CMD_PREPAIR_COPY_SHEET;
-
-                ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, imgDataOffset - (ctx->mDataOffset + reader->getCurrentOffset()), prepCmd);
+                ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, imgDataOffset - ctx->getFullOffset(reader), prepCmd);
                 return CONSTRUCT_STATE_WORKING;
             }
 
@@ -701,8 +529,7 @@ namespace nw4r {
                 }
                 sheetSize = ctx->pFontInfo->pGlyph->sheetSize;
                 if (ctx->pSheetOffsets[ctx->mSheetsHandled] != GLYPH_INDEX_NOT_FOUND) {
-                    if (ctx->remWorkSpace() < sheetSize)
-                        return CONSTRUCT_STATE_FATAL_ERR;
+                    ENSURE_WORK_HAS_SIZE(ctx, sheetSize);
                     ctx->enqueueCmds(CONSTRUCT_CMD_COPY, sheetSize, CONSTRUCT_CMD_PREPAIR_COPY_SHEET);
                 } else {
                     ctx->enqueueCmds(CONSTRUCT_CMD_SKIP, sheetSize, CONSTRUCT_CMD_PREPAIR_COPY_SHEET);
@@ -719,16 +546,14 @@ namespace nw4r {
                     ctx->mNextCmd = CONSTRUCT_CMD_DISPATCH;
                     return CONSTRUCT_STATE_WORKING;
                 }
-                ENSURE_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
+                ENSURE_READER_HAS_SIZE(ctx, reader, sizeof(BinaryBlockHeader));
                 reader->memcpyToBuf(compressedSizeBuf, 4);
                 memcpy(compressedDataHdr, reader->pDataCurr, 4);
                 compressedSize = *(u32*)(u8*)compressedSizeBuf;
 
                 uncompressedSize = CXGetUncompressedSize(compressedDataHdr);
                 if (ctx->pSheetOffsets[ctx->mSheetsHandled] != GLYPH_INDEX_NOT_FOUND) {
-                    if (ctx->remWorkSpace() < compressedSize + sizeof(CXUncompContextHuffman))
-                        return CONSTRUCT_STATE_FATAL_ERR;
-
+                    ENSURE_WORK_HAS_SIZE(ctx, compressedSize + sizeof(CXUncompContextHuffman));
                     CXInitUncompContextHuffman(ctx->pHuffmanCtx, ctx->pWorkCurr);
 
                     ctx->enqueueCmds(CONSTRUCT_CMD_EXPAND, compressedSize, CONSTRUCT_CMD_PREPAIR_EXPAND_SHEET);
@@ -762,24 +587,9 @@ namespace nw4r {
                 return handleAdvanceDry(ctx, reader, copySize);
             }
             ArchiveFontBase::ConstructState ArchiveFontBase::ConstructOpSkip(ConstructContext* ctx, CachedStreamReader* reader) {
-                u8* start;
-                u32 dataLen, cachedLen;
-                u8* end;
-
                 u32 skipSize;
-
-                skipSize = getAdvanceSize(ctx, reader);
-
-                end = reader->pCachedEnd;
-                start = reader->pCachedStart;
-                cachedLen = end - start;
-                if (cachedLen > skipSize) {
-                    reader->pCachedStart = start + skipSize;
-                } else {
-                    dataLen = skipSize - cachedLen;
-                    reader->pCachedStart = end;
-                    reader->pDataCurr += dataLen;
-                }
+                skipSize = ctx->getAdvanceSize(reader);
+                reader->skip(skipSize);
 
                 return handleAdvanceDry(ctx, reader, skipSize);
             }
@@ -787,10 +597,11 @@ namespace nw4r {
                 u32 cmprSize;
                 u8* src;
 
-                cmprSize = getAdvanceSize(ctx, reader);
+                // @bug I think this should be more like ConstructOpCopy where it checks the size of data rather than cached?
+                cmprSize = ctx->getAdvanceSize(reader);
 
                 src = reader->pDataCurr;
-                reader->pDataCurr = reader->pDataCurr + cmprSize;
+                reader->pDataCurr += cmprSize;
                 CXReadUncompHuffman(ctx->pHuffmanCtx, src, cmprSize);
 
                 return handleAdvanceDry(ctx, reader, cmprSize);

--- a/libs/RVL_SDK/include/revolution/cx/CXStreamingUncompression.h
+++ b/libs/RVL_SDK/include/revolution/cx/CXStreamingUncompression.h
@@ -37,25 +37,34 @@ typedef struct CXUncompContextLZ {
     u8 padding[3];
 } CXUncompContextLZ;
 
+typedef union CXHuffmanDecodeTableEntry {
+    u8 raw;
+    struct {
+        u8 leafR : 1;      // 10000000
+        u8 leafL : 1;      // 01000000
+        u8 idxOffset : 6;  // 00111111
+    };
+} CXHuffmanDecodeTableEntry;
+
 typedef struct CXUncompContextHuffman {
-    int* unk_0x00;  // 0x00
-    int unk_0x04;   // 0x04
-    int unk_0x08;   // 0x08
-    u8* unk_0x0c;   // 0x0C
-    u32 unk_0x10;   // 0x10
-    u32 unk_0x14;   // 0x14
-    s16 unk_0x18;   // 0x18
-    u8 unk_0x1a;    // 0x1A
-    u8 unk_0x1b;    // 0x1B
-    u8 unk_0x1c;    // 0x1C
-    u8 unk_0x1d;    // 0x1D
-    u8 padding[2];
-    u8 unk_0x20[2];  // 0x20
+    u32* outData;                                      // 0x00
+    int outDataLen;                                    // 0x04
+    int unk_0x08;                                      // 0x08
+    CXHuffmanDecodeTableEntry* decodeTable;            // 0x0C
+    u32 bits;                                          // 0x10
+    u32 unk_0x14;                                      // 0x14
+    s16 decodeTableSize;                               // 0x18
+    u8 bitsLeft;                                       // 0x1A
+    u8 unk_0x1b;                                       // 0x1B
+    u8 depth;                                          // 0x1C
+    u8 hdrLen;                                         // 0x1D
+    u8 padding[2];                                     // 0x1E
+    CXHuffmanDecodeTableEntry decodeTableData[0x200];  // 0x20
 } CXUncompContextHuffman;
 
 void CXInitUncompContextRL(CXUncompContextRL* context, u8* param_2);
 void CXInitUncompContextLZ(CXUncompContextLZ* context, u8* param_2);
-void CXInitUncompContextHuffman(CXUncompContextHuffman* context, int* param_2);
+void CXInitUncompContextHuffman(CXUncompContextHuffman* context, u8* param_2);
 
 CXStreamingResult CXReadUncompRL(CXUncompContextRL* context, const void* src, u32 size);
 CXStreamingResult CXReadUncompLZ(CXUncompContextLZ* context, const void* src, u32 size);

--- a/libs/RVL_SDK/src/cx/CXStreamingUncompression.c
+++ b/libs/RVL_SDK/src/cx/CXStreamingUncompression.c
@@ -2,7 +2,7 @@
 #include <revolution/cx.h>
 
 static inline int CXiReadHeader(u8*, int*, const u8*, int, int);
-static inline u8* GetNextNode(u8*, int);
+static inline CXHuffmanDecodeTableEntry* GetNextNode(CXHuffmanDecodeTableEntry*, int);
 
 void CXInitUncompContextRL(CXUncompContextRL* context, u8* param_2) {
     context->unk_0x00 = param_2;
@@ -25,17 +25,17 @@ void CXInitUncompContextLZ(CXUncompContextLZ* context, u8* param_2) {
     context->unk_0x08 = 0;
 }
 
-void CXInitUncompContextHuffman(CXUncompContextHuffman* context, int* param_2) {
-    context->unk_0x00 = param_2;
-    context->unk_0x04 = 0;
-    context->unk_0x1c = 0;
-    context->unk_0x18 = -1;
-    context->unk_0x0c = context->unk_0x20;
+void CXInitUncompContextHuffman(CXUncompContextHuffman* context, u8* data) {
+    context->outData = (u32*)data;
+    context->outDataLen = 0;
+    context->depth = 0;
+    context->decodeTableSize = -1;
+    context->decodeTable = context->decodeTableData;
     context->unk_0x14 = 0;
     context->unk_0x1b = 0;
-    context->unk_0x10 = 0;
-    context->unk_0x1a = 0;
-    context->unk_0x1d = 8;
+    context->bits = 0;
+    context->bitsLeft = 0;
+    context->hdrLen = 8;
     context->unk_0x08 = 0;
 }
 
@@ -125,36 +125,36 @@ CXStreamingResult CXReadUncompRL(CXUncompContextRL* context, const void* src, u3
     return CX_STREAMING_ERR_OK;
 }
 
-static int CXiReadHeader(u8* param_1, int* param_2, const u8* param_3, int param_4, int param_5) {
-    int a = 0;
+static int CXiReadHeader(u8* pHdrLen, int* pOutLen, const u8* pSrc, int srcSize, int param_5) {
+    int bytesParsed = 0;
 
-    while (*param_1) {
-        (*param_1)--;
+    while (*pHdrLen) {
+        (*pHdrLen)--;
 
-        if (*param_1 <= 3) {
-            *param_2 |= *param_3 << ((3 - *param_1) << 3);
-        } else if (*param_1 <= 6) {
-            *param_2 |= *param_3 << ((6 - *param_1) << 3);
+        if (*pHdrLen <= 3) {
+            *pOutLen |= *pSrc << ((3 - *pHdrLen) << 3);
+        } else if (*pHdrLen <= 6) {
+            *pOutLen |= *pSrc << ((6 - *pHdrLen) << 3);
         }
 
-        param_3++;
-        a++;
+        pSrc++;
+        bytesParsed++;
 
-        if (*param_1 == 4 && *param_2 > 0) {
-            *param_1 = 0;
+        if (*pHdrLen == 4 && *pOutLen > 0) {
+            *pHdrLen = 0;
         }
 
-        param_4--;
-        if (param_4 == 0 && *param_1 != 0) {
-            return a;
+        srcSize--;
+        if (srcSize == 0 && *pHdrLen != 0) {
+            return bytesParsed;
         }
     }
 
-    if (param_5 > 0 && param_5 < *param_2) {
-        *param_2 = param_5;
+    if (param_5 > 0 && param_5 < *pOutLen) {
+        *pOutLen = param_5;
     }
 
-    return a;
+    return bytesParsed;
 }
 
 CXStreamingResult CXReadUncompLZ(CXUncompContextLZ* context, const void* src, u32 size) {
@@ -294,97 +294,98 @@ out:
 CXStreamingResult CXReadUncompHuffman(CXUncompContextHuffman* context, const void* src, u32 size) {
     const u8* pSrc = src;
 
-    if (context->unk_0x1d) {
+    if (context->hdrLen) {
         int a;
-        if (context->unk_0x1d == 8) {
-            context->unk_0x1c = *pSrc & 0x0F;
+        if (context->hdrLen == 8) {
+            context->depth = *pSrc & 0x0F;
 
             if ((*pSrc & CX_COMPRESSION_TYPE_MASK) != CX_COMPRESSION_TYPE_HUFFMAN) {
                 return CX_STREAMING_ERR_BAD_FILE_TYPE;
             }
 
-            if (context->unk_0x1c != 4 && context->unk_0x1c != 8) {
+            if (context->depth != 4 && context->depth != 8) {
                 return CX_STREAMING_ERR_BAD_FILE_TYPE;
             }
         }
 
-        a = CXiReadHeader(&context->unk_0x1d, &context->unk_0x04, pSrc, size, context->unk_0x08);
+        a = CXiReadHeader(&context->hdrLen, &context->outDataLen, pSrc, size, context->unk_0x08);
 
         pSrc += a;
         size -= a;
 
         if (!size) {
-            return !context->unk_0x1d ? context->unk_0x04 : CX_STREAMING_ERR_BAD_FILE_TYPE;
+            return !context->hdrLen ? context->outDataLen : CX_STREAMING_ERR_BAD_FILE_TYPE;
         }
     }
 
-    if (context->unk_0x18 < 0) {
-        context->unk_0x18 = ((*pSrc + 1) << 1) - 1;
-        *context->unk_0x0c++ = *pSrc++;
+    if (context->decodeTableSize < 0) {
+        context->decodeTableSize = ((*pSrc + 1) << 1) - 1;
+        (context->decodeTable++)->raw = *pSrc++;
         size--;
     }
 
-    while (context->unk_0x18 > 0) {
+    while (context->decodeTableSize > 0) {
         if (!size) {
-            return context->unk_0x04;
+            return context->outDataLen;
         }
 
-        *context->unk_0x0c++ = *pSrc++;
-        context->unk_0x18--;
+        (context->decodeTable++)->raw = *pSrc++;
+        context->decodeTableSize--;
         size--;
 
-        if (context->unk_0x18) {
+        if (context->decodeTableSize) {
             continue;
         }
 
-        context->unk_0x0c = context->unk_0x20 + 1;
+        // Done copying decodeTable
+        context->decodeTable = context->decodeTableData + 1;
 
-        if (!CXiVerifyHuffmanTable_(context->unk_0x20, context->unk_0x1c)) {
+        if (!CXiVerifyHuffmanTable_(context->decodeTableData, context->depth)) {
             return CX_STREAMING_ERR_BAD_FILE_TABLE;
         }
     }
 
-    while (context->unk_0x04 > 0) {
-        while (context->unk_0x1a < 32) {
+    while (context->outDataLen > 0) {
+        while (context->bitsLeft < 32) {
             if (!size) {
-                return context->unk_0x04;
+                return context->outDataLen;
             }
 
-            context->unk_0x10 |= *pSrc++ << context->unk_0x1a;
+            context->bits |= *pSrc++ << context->bitsLeft;
 
             size--;
-            context->unk_0x1a += 8;
+            context->bitsLeft += 8;
         }
 
-        while (context->unk_0x1a) {
-            int b = context->unk_0x10 >> 31;
-            int c = (*(vu8*)context->unk_0x0c << b) & 0x80;  // ?
+        while (context->bitsLeft) {
+            BOOL currBit = context->bits >> 31;
+            int c = (*(vu8*)context->decodeTable << currBit) & 0x80;  // ?
 
-            context->unk_0x0c = GetNextNode(context->unk_0x0c, b);
-            context->unk_0x10 <<= 1;
-            context->unk_0x1a--;
+            context->decodeTable = GetNextNode((CXHuffmanDecodeTableEntry*)context->decodeTable, currBit);
+            context->bits <<= 1;
+            context->bitsLeft--;
 
             if (!c) {
                 continue;
             }
 
-            context->unk_0x14 >>= context->unk_0x1c;
-            context->unk_0x14 |= *context->unk_0x0c << (32 - context->unk_0x1c);
-            context->unk_0x0c = context->unk_0x20 + 1;
-            context->unk_0x1b += context->unk_0x1c;
+            context->unk_0x14 >>= context->depth;
+            context->unk_0x14 |= context->decodeTable->raw << (32 - context->depth);
+            context->decodeTable = context->decodeTableData + 1;
+            context->unk_0x1b += context->depth;
 
             if (context->unk_0x1b == 32) {
-                *context->unk_0x00 = CXiConvertEndian32_(context->unk_0x14);
-                context->unk_0x00++;
-                context->unk_0x04 -= 4;
+                *context->outData = CXiConvertEndian32_(context->unk_0x14);
+                context->outData++;
+                context->outDataLen -= 4;
                 context->unk_0x1b = 0;
 
-                if (context->unk_0x04 <= 0) {
+                if (context->outDataLen <= 0) {
                     goto out;
                 }
             }
 
-            (void)b;
+            (void)currBit;
         }
     }
 
@@ -396,6 +397,6 @@ out:
     return CX_STREAMING_ERR_OK;
 }
 
-static u8* GetNextNode(u8* param_1, int param_2) {
-    return (u8*)ROUNDDOWN((u32)param_1, 2) + (((*param_1 & 0x3f) + 1) << 1) + param_2;
+static CXHuffmanDecodeTableEntry* GetNextNode(CXHuffmanDecodeTableEntry* pDecodeTable, BOOL currBit) {
+    return (CXHuffmanDecodeTableEntry*)ROUNDDOWN((u32)pDecodeTable, 2) + (((*pDecodeTable).idxOffset + 1) << 1) + currBit;
 }


### PR DESCRIPTION
Still working on this, but creating a draft pull request to make some of the work on this public.

Current status as of writing this:
| Class | Match% | Notes |
|--------|--------|--------|
| `ArchiveFont` | 97.41% | Mostly matching There's just some regswaps in `GetRequireBufferSize` and a load order thing in `StreamingConstruct`, but those are definitely equivalent. No blatant fake matches. |
| `ArchiveFontBase` | 97.98% | Lots of fake matches using `FORCE_REACCESS`, that's what I'm mostly working on. `ConstructOpAnalyzeGLGR` is nonmatching, but I think equivalent. (Not as sure about that as the ones in `ArchiveFont`.) |
| `ArchiveFontBase::CachedStreamReader` | 100.00% | `RequestData` has some `FORCE_REACCESS` things, so I'll need to figure out how to unfake that. |

I'm excited to have the `nw4r` for this project fully equivalent soon (or Soon™, who knows)!
