### PR TITLE
VFSysGetFileSizeByFd matching

### DIFF
--- a/libs/RevoEX/src/vf/develop/d_vf_sys.c
+++ b/libs/RevoEX/src/vf/develop/d_vf_sys.c
@@ -801,7 +801,7 @@ s32 VFSysCreateDir(s32 i_handle_idx, const char* i_dir_name_p) {
 }
 
 s32 VFSysGetFileSizeByFd(s32* o_size_p, PF_FILE* i_file_p) {
-    *o_size_p = -1;
+    *o_size_p = 0;
     if (i_file_p != NULL) {
         PF_INFO info;
         if (VFipf2_finfo(i_file_p, &info) == 0) {


### PR DESCRIPTION
Fixes the initial value of `*o_size_p` so the function matches the original asm.

The original initializes the out param to `0` before the null-check on `i_file_p`, then returns `VF_ERR_SYSTEM` (-1) via `r3` when `i_file_p` is NULL. The previous source initialized it to `-1` instead.

Builds and `build.sha1` check pass.