### PR TITLE
Manager::titleIDtoPageIndex(), ChannelObj::calcBalloon() matching

### DIFF
--- a/src/scene/channelSelect/iplChannelObj.cpp
+++ b/src/scene/channelSelect/iplChannelObj.cpp
@@ -1011,7 +1011,7 @@ namespace ipl {
 
                 size = mpBalloonLayout->FindPaneByName(scBasePane)->GetSize();
 
-                f32 val = -2.0f + (mThumbHeight + (size.height / 2));
+                f32 val = -2.0f + ((size.height / 2) + mThumbHeight);
                 val *= -1.0f;
 
                 nw4r::ut::Rect projRect;

--- a/src/system/iplChannelManager.cpp
+++ b/src/system/iplChannelManager.cpp
@@ -1090,7 +1090,8 @@ namespace ipl {
                 for (int index = 0; index < MAX_CHANNEL_INDEX; index++) {
                     if (mChannels[page][index].loadedBnr) {
                         if (mChannels[page][index].info.primaryType == PRIMARY_TYPE_CHANNEL) {
-                            if (ES_TITLE_ID(mChannels[page][index].info.titleType, mChannels[page][index].info.titleCode) == titleId) {
+                            ESTitleId currentId = ES_TITLE_ID(mChannels[page][index].info.titleType, mChannels[page][index].info.titleCode);
+                            if (currentId == titleId) {
                                 *outPage = page;
                                 *outIndex = index;
                                 return;


### PR DESCRIPTION
Two small matching fixes by nudging operand order in commutative operations.

- `Manager::titleIDtoPageIndex` (`iplChannelManager.cpp`): extracted `ES_TITLE_ID(...)` to a local before the `==`. This flips the operand order in the two `xor` instructions emitted for the 64-bit equality comparison (`xor r10, r10, r5` instead of `xor r10, r5, r10`).
- `ChannelObj::calcBalloon` (`iplChannelObj.cpp`): reparenthesized the addition `mThumbHeight + (size.height / 2)` to `(size.height / 2) + mThumbHeight`, which flips the `fadds` operand order.

Both functions go from regswap-only diffs to byte-perfect match. Build and SHA1 check pass.