### PR TITLE
Manager::getAvailableNumInList(), Board::focus(), Board::stt_focus() matching

### DIFF
--- a/include/system/MESGEntries.h
+++ b/include/system/MESGEntries.h
@@ -76,8 +76,8 @@
 #define MESG_BOARD_CHJUMP_CONFIRM       88
 #define MESG_BOARD_CHJUMP_NO_OPERA      89
 #define MESG_BOARD_CHJUMP_LAUNCH_ERROR  90
-#define MESG_BOARD_OPT_OUT              92
 #ifndef VERSION_43E
+#define MESG_BOARD_OPT_OUT              101
 #define MESG_BOARD_OPT_OUT_SELECT       102
 #define MESG_BOARD_OPT_OUT_ONE          103
 #define MESG_BOARD_OPT_OUT_ALL          104
@@ -87,6 +87,7 @@
 #define MESG_BOARD_OPT_OUT_DONE_ALL     108
 #define MESG_BOARD_NWC24_DELETE_FAIL    109
 #else
+#define MESG_BOARD_OPT_OUT              92
 #define MESG_BOARD_OPT_OUT_SELECT       93
 #define MESG_BOARD_OPT_OUT_ONE          94
 #define MESG_BOARD_OPT_OUT_ALL          95

--- a/src/system/iplSaveDataManager.cpp
+++ b/src/system/iplSaveDataManager.cpp
@@ -532,7 +532,7 @@ namespace ipl {
         int Manager::getAvailableNumInList(const ESTitleId* titleIds, u32 titleCount) {
             int count = 0;
             for (int i = 0; i < titleCount; i++) {
-                if (titleIds[i] != 0) {
+                if (titleIds[i] == 0) {
                     count++;
                 }
             }


### PR DESCRIPTION
Two fixes:

- `iplSaveDataManager.cpp`: `Manager::getAvailableNumInList()` had inverted condition — counted non-zero entries instead of zero entries. The original DOL counts empties (consistent with the function name `getAvailable...`). Changed `!= 0` → `== 0`. Function 100%.
- `MESGEntries.h`: `MESG_BOARD_OPT_OUT` should be 101 in 43U (and presumably 43J/43K), not 92. Only 43E uses 92. Moved the macro into the existing `VERSION_43E`/non-43E split. This brings `Board::focus()` and `Board::stt_focus()` to 100%.

`build.sha1` check passes.