### PR TITLE
EGG::GraphicsFifo matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1906,7 +1906,7 @@ config.libs = [
             Object(NonMatching, "core/eggDisposer.cpp"),
             Object(NonMatching, "core/eggExpHeap.cpp"),
             Object(NonMatching, "core/eggFrmHeap.cpp"),
-            Object(NonMatching, "core/eggGraphicsFifo.cpp"),
+            Object(Matching,    "core/eggGraphicsFifo.cpp", extra_cflags=["-O4,s"]),
             Object(NonMatching, "core/eggHeap.cpp"),
             Object(NonMatching, "core/eggTaskThread.cpp"),
             Object(NonMatching, "core/eggThread.cpp"),

--- a/libs/EGG/include/egg/core/eggHeap.h
+++ b/libs/EGG/include/egg/core/eggHeap.h
@@ -53,6 +53,11 @@ namespace EGG {
         }
         static Heap* unkInline2(int id = 0) { return (Heap*)OSGetThreadSpecific(id); }
 
+        static void* alloc(u32 size, int align, Heap* heap);
+        static void free(void* buffer, Heap* heap);
+
+        static Heap* sCurrentHeap;
+
         void* getStartAddress() { return this; }
         void* getEndAddress() { return MEMGetHeapEndAddress(mHeapHandle); }
 

--- a/libs/EGG/src/core/eggGraphicsFifo.cpp
+++ b/libs/EGG/src/core/eggGraphicsFifo.cpp
@@ -1,0 +1,34 @@
+#pragma ipa file
+
+#include <egg/core/eggGraphicsFifo.h>
+
+#include <revolution/gx/GXManage.h>
+
+namespace EGG {
+
+    GraphicsFifo* GraphicsFifo::sGraphicsFifo;
+    GraphicsFifo::GpStatus GraphicsFifo::sGpStatus;
+
+#pragma dont_inline on
+    GraphicsFifo* GraphicsFifo::create(u32 size, Heap* pHeap) {
+        if (pHeap == NULL) {
+            pHeap = Heap::sCurrentHeap;
+        }
+        sGraphicsFifo = new (pHeap, 4) GraphicsFifo(size, pHeap);
+        return sGraphicsFifo;
+    }
+#pragma dont_inline off
+
+    GraphicsFifo::~GraphicsFifo() {
+        while (isGPActive()) {}
+        Heap::free(mpBuffer, NULL);
+    }
+
+    GraphicsFifo::GraphicsFifo(u32 size, Heap* pHeap) {
+        mBufSize = (size + 0x1F) & ~0x1F;
+        void* buffer = Heap::alloc(mBufSize + 0xA0, 0x20, pHeap);
+        mpBuffer = (void*)(((u32)buffer + 0x1F) & ~0x1F);
+        mpFifoObj = GXInit(mpBuffer, mBufSize);
+    }
+
+}  // namespace EGG


### PR DESCRIPTION
Implements `EGG::GraphicsFifo` (`create`, ctor, dtor) at byte-perfect 100% match.

Key insight: this file needs `-O4,s` (size optimization) instead of the default `-O4,p` (speed) — the original was compiled with size optimization, which is why mwcc emits `_savegpr_29` / `_restgpr_29` helpers in the dtor prolog/epilogue. With `-O4,p`, mwcc inlines the saves as separate `stw`s and the function diverges from target.

Same pattern as `iplUrlProcessor::url_collision::~url_collision()` which is currently flagged `Equivalent`. Re-flagging that file with `-O4,s` may also bring it to 100% (left out of this PR to keep the change small).

Adds three static helper declarations to `eggHeap.h` (`sCurrentHeap`, `alloc`, `free`) needed by the FIFO. These complement (don't conflict with) the additions in #10.

Builds and `build.sha1` check pass.