### PR TITLE
EGG::SoundHeapMgr matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1901,7 +1901,7 @@ config.libs = [
             Object(NonMatching, "core/eggAudioExpMgr.cpp"),
             Object(NonMatching, "core/eggAudioFxMgr.cpp"),
             Object(NonMatching, "core/eggAudioMgr.cpp"),
-            Object(NonMatching, "core/eggAudioHeapMgr.cpp"),
+            Object(Matching,    "core/eggAudioHeapMgr.cpp"),
             Object(NonMatching, "core/eggColorFader.cpp"),
             Object(NonMatching, "core/eggDisposer.cpp"),
             Object(NonMatching, "core/eggExpHeap.cpp"),

--- a/libs/EGG/include/egg/core/eggAudioHeapMgr.h
+++ b/libs/EGG/include/egg/core/eggAudioHeapMgr.h
@@ -1,0 +1,24 @@
+#ifndef EGG_CORE_AUDIO_HEAP_MGR_H
+#define EGG_CORE_AUDIO_HEAP_MGR_H
+
+#include <egg/core/eggAllocator.h>
+
+#include <nw4r/snd/SoundHeap.h>
+
+namespace EGG {
+    class SoundHeapMgr {
+    public:
+        SoundHeapMgr() {}
+        virtual ~SoundHeapMgr() {
+            destroySoundHeap();
+        }
+
+        void createSoundHeap(Allocator* pAllocator, u32 size);
+        void destroySoundHeap();
+
+    protected:
+        nw4r::snd::SoundHeap mHeap;  // 0x04
+    };
+}  // namespace EGG
+
+#endif  // EGG_CORE_AUDIO_HEAP_MGR_H

--- a/libs/EGG/src/core/eggAudioHeapMgr.cpp
+++ b/libs/EGG/src/core/eggAudioHeapMgr.cpp
@@ -1,0 +1,17 @@
+#include <egg/core/eggAudioHeapMgr.h>
+
+namespace EGG {
+
+    void SoundHeapMgr::createSoundHeap(Allocator* pAllocator, u32 size) {
+        if (mHeap.IsValid()) {
+            return;
+        }
+        void* buffer = pAllocator->alloc(size);
+        mHeap.Create(buffer, size);
+    }
+
+    void SoundHeapMgr::destroySoundHeap() {
+        mHeap.Destroy();
+    }
+
+}  // namespace EGG


### PR DESCRIPTION
Implements `EGG::SoundHeapMgr` with both `createSoundHeap` and `destroySoundHeap` at 100% match.

Adds new header `libs/EGG/include/egg/core/eggAudioHeapMgr.h` with a minimal `SoundHeapMgr` class:
- `mHeap` (`nw4r::snd::SoundHeap`) at offset 0x4
- vtable at 0x0
- `createSoundHeap(Allocator*, u32)` and `destroySoundHeap()` non-virtual

The Wii Menu's version of `SoundHeapMgr` appears to be simpler than ogws's (no message queue state machine — only the two methods present in the asm). Layout deduced from the asm and `nw4r::snd::SoundHeap` struct in the project.

Builds and `build.sha1` check pass.