### PR TITLE
EGG::Thread + TaskThread::TJob::findBlank matching

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1909,7 +1909,7 @@ config.libs = [
             Object(NonMatching, "core/eggGraphicsFifo.cpp"),
             Object(NonMatching, "core/eggHeap.cpp"),
             Object(NonMatching, "core/eggTaskThread.cpp"),
-            Object(NonMatching, "core/eggThread.cpp"),
+            Object(Matching,    "core/eggThread.cpp", extra_cflags=["-O4,s"]),
             Object(NonMatching, "core/eggUnitHeap.cpp"),
 
             Object(NonMatching, "prim/eggAssert.cpp"),

--- a/libs/EGG/include/egg/core/eggHeap.h
+++ b/libs/EGG/include/egg/core/eggHeap.h
@@ -53,6 +53,11 @@ namespace EGG {
         }
         static Heap* unkInline2(int id = 0) { return (Heap*)OSGetThreadSpecific(id); }
 
+        static void* alloc(u32 size, int align, Heap* heap);
+        static void free(void* buffer, Heap* heap);
+
+        static Heap* sCurrentHeap;
+
         void* getStartAddress() { return this; }
         void* getEndAddress() { return MEMGetHeapEndAddress(mHeapHandle); }
 

--- a/libs/EGG/include/egg/core/eggTaskThread.h
+++ b/libs/EGG/include/egg/core/eggTaskThread.h
@@ -19,14 +19,9 @@ namespace EGG {
             TFunction mExitFunction;   // 0x10
             TFunction unk_0x14;
 
-            inline TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
+            TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
 
-            inline void clearFunctions() {
-                mFunction = NULL;
-                mEnterFunction = NULL;
-                mExitFunction = NULL;
-                unk_0x14 = NULL;
-            }
+            void clear_functions();
         } TJob;
 
         TaskThread();
@@ -42,6 +37,9 @@ namespace EGG {
         void setMessageQueue(OSMessageQueue* queue) { mpMsgQueue = queue; }
 
         static OSMessage waitQueueMessage(OSMessageQueue* queue, BOOL* result);
+
+    private:
+        TJob* findBlank();
 
     private:
         TJob* mCurrentJob;  // 0x44

--- a/libs/EGG/include/egg/core/eggThread.h
+++ b/libs/EGG/include/egg/core/eggThread.h
@@ -11,27 +11,44 @@
 namespace EGG {
     class Thread {
     public:
-        Thread(OSThread* currThread, int);
+        static void initialize();
+        static Thread* findThread(OSThread* pOSThread);
+
+        Thread(u32 stackSize, int capacity, int priority, Heap* pHeap = NULL);
+        Thread(OSThread* currThread, int capacity);
         virtual ~Thread();
 
-        static void initialize();
+        virtual void* run();
+
+        virtual void onEnter();
+        virtual void onExit();
 
         OSMessageQueue* getMessageQueue() { return &mMsgQueue; }
+        OSThread* getOSThread() const { return mpThread; }
 
     private:
-        static nw4r::ut::List smThreadList;
+        void setCommonMesgQueue(int capacity, Heap* pHeap);
 
-        Heap* mpHeap;        // 0x04
-        OSThread* mpThread;  // 0x08
+        static void switchThreadCallback(OSThread* pCurrOSThread, OSThread* pNewOSThread);
+        static void* start(void* pArg);
 
-        OSMessageQueue mMsgQueue;  // 0x0C
-        void* mpMsgArray;          // 0x2C
-        s32 mMsgCount;             // 0x30
+    private:
+        nw4r::ut::Link mLink;  // 0x04
 
-        void* mpStack;   // 0x34
-        u32 mStackSize;  // 0x38
+        Heap* mpHeap;        // 0x0C
+        OSThread* mpThread;  // 0x10
 
-        nw4r::ut::Link mLink;  // 0x3C
+        OSMessageQueue mMsgQueue;  // 0x14
+        void* mpMsgArray;          // 0x34
+        s32 mMsgCount;             // 0x38
+
+        void* mpStack;   // 0x3C
+        u32 mStackSize;  // 0x40
+
+        struct ThreadList : public nw4r::ut::List {
+            u32 _pad;
+        };
+        static ThreadList sThreadList;
     };
 }  // namespace EGG
 

--- a/libs/EGG/src/core/eggThread.cpp
+++ b/libs/EGG/src/core/eggThread.cpp
@@ -1,0 +1,96 @@
+#include <egg/core/eggThread.h>
+
+#include <egg/core/eggTaskThread.h>
+
+namespace EGG {
+
+    Thread::ThreadList Thread::sThreadList;
+
+    TaskThread::TJob* TaskThread::findBlank() {
+        for (int i = 0; i < mJobCount; i++) {
+            if (mJobs[i].mFunction == NULL) {
+                mJobs[i].clear_functions();
+                return &mJobs[i];
+            }
+        }
+        return NULL;
+    }
+
+    void Thread::switchThreadCallback(OSThread* pCurrOSThread, OSThread* pNewOSThread) {
+        Thread* pCurrThread = findThread(pCurrOSThread);
+        Thread* pNewThread = findThread(pNewOSThread);
+        if (pCurrThread != NULL) {
+            pCurrThread->onExit();
+        }
+        if (pNewThread != NULL) {
+            pNewThread->onEnter();
+        }
+    }
+
+    void Thread::onEnter() {}
+    void Thread::onExit() {}
+
+    Thread::Thread(u32 stackSize, int capacity, int priority, Heap* pHeap) {
+        if (pHeap == NULL) {
+            pHeap = Heap::sCurrentHeap;
+        }
+        mpHeap = pHeap;
+        mStackSize = stackSize & ~0x1F;
+        mpStack = Heap::alloc(mStackSize, 0x20, mpHeap);
+        mpThread = (OSThread*)Heap::alloc(sizeof(OSThread), 0x20, mpHeap);
+        OSCreateThread(mpThread, Thread::start, this, (u8*)mpStack + mStackSize, mStackSize, priority, OS_THREAD_ATTR_DETACH);
+        setCommonMesgQueue(capacity, mpHeap);
+    }
+
+    Thread::Thread(OSThread* currThread, int capacity) {
+        mpHeap = NULL;
+        mpThread = currThread;
+        mStackSize = (u32)((u8*)currThread->stackEnd - (u8*)currThread->stackBase);
+        mpStack = currThread->stackBase;
+        setCommonMesgQueue(capacity, Heap::sCurrentHeap);
+    }
+
+    Thread::~Thread() {
+        nw4r::ut::List_Remove(&sThreadList, this);
+        if (mpHeap != NULL) {
+            if (!OSIsThreadTerminated(mpThread)) {
+                OSDetachThread(mpThread);
+                OSCancelThread(mpThread);
+            }
+            Heap::free(mpStack, mpHeap);
+            Heap::free(mpThread, mpHeap);
+        }
+        Heap::free(mpMsgArray, NULL);
+    }
+
+    Thread* Thread::findThread(OSThread* pOSThread) {
+        Thread* it = NULL;
+        while ((it = (Thread*)nw4r::ut::List_GetNext(&sThreadList, it)) != NULL) {
+            if (it->mpThread == pOSThread) {
+                return it;
+            }
+        }
+        return NULL;
+    }
+
+    void Thread::initialize() {
+        nw4r::ut::List_Init(&sThreadList, offsetof(Thread, mLink));
+        OSSetSwitchThreadCallback(Thread::switchThreadCallback);
+    }
+
+    void Thread::setCommonMesgQueue(int capacity, Heap* pHeap) {
+        mMsgCount = capacity;
+        mpMsgArray = Heap::alloc(capacity * sizeof(OSMessage), 4, pHeap);
+        OSInitMessageQueue(&mMsgQueue, (OSMessage*)mpMsgArray, mMsgCount);
+        nw4r::ut::List_Append(&sThreadList, this);
+    }
+
+    void* Thread::start(void* pArg) {
+        return ((Thread*)pArg)->run();
+    }
+
+    void* Thread::run() {
+        return NULL;
+    }
+
+}  // namespace EGG

--- a/src/system/iplErrorHandler.cpp
+++ b/src/system/iplErrorHandler.cpp
@@ -53,7 +53,7 @@ namespace ipl {
         }
 
         curThread = OSGetCurrentThread();
-        if (curThread == System::getMainThread()->getMessageQueue()->queueSend.tail) {
+        if (curThread == System::getMainThread()->getOSThread()) {
             check();
         } else {
             OSCancelThread(curThread);


### PR DESCRIPTION
Implements `EGG::Thread` (12 functions) and `EGG::TaskThread::TJob::findBlank` at 100% match.

## Summary
- Adds `libs/EGG/src/core/eggThread.cpp` with all 12 functions matching: ctor (4-arg), ctor (OSThread, int), ~Thread, findThread, initialize, switchThreadCallback, onEnter, onExit, setCommonMesgQueue, start, run, plus TaskThread::TJob::findBlank (which the original DOL emits into eggThread.o).
- Updates `eggThread.h` Thread layout: `mLink` is at offset 0x4 (not 0x3C), pushing `mpHeap` to 0xC, `mpThread` to 0x10, `mMsgQueue` to 0x14, etc. Class size unchanged (0x44).
- Adds `Thread::getOSThread()` accessor.
- Adds 4-byte trailing pad to `Thread::sThreadList` storage (target reserves 16 bytes for it; using a `ThreadList : nw4r::ut::List` wrapper to avoid touching `nw4r::ut::List` itself, which is 12 bytes and used elsewhere).
- Renames `EGG::TaskThread::TJob::clearFunctions` to `clear_functions` (matches the original mangled symbol) and moves it out-of-line. Adds the private `findBlank` declaration to `eggTaskThread.h`.
- Adds 3 static helpers to `eggHeap.h` (`sCurrentHeap`, `alloc`, `free`) needed by the Thread implementation. Same pattern as #16.

## Side fix
- `iplErrorHandler.cpp`: the comparison `curThread == ...->getMessageQueue()->queueSend.tail` is now `curThread == ...->getOSThread()`. The previous source was a misinterpretation — under the old (incorrect) Thread layout, `mMsgQueue.queueSend.tail` happened to land at the same offset as `mpThread`, making the source compile to the right asm "by accident". With the corrected layout this no longer holds, so the source is updated to match the original intent.

## Compiler flag
Uses `-O4,s` per the same trick as #16 — the original was compiled with size optimization, which produces `_savegpr_29` / `_restgpr_29` helpers in the prolog/epilog of several functions.

Builds and `build.sha1` check pass.