### PR TITLE
Match EGG::Thread and EGG::TaskThread

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1908,7 +1908,7 @@ config.libs = [
             Object(NonMatching, "core/eggFrmHeap.cpp"),
             Object(NonMatching, "core/eggGraphicsFifo.cpp"),
             Object(NonMatching, "core/eggHeap.cpp"),
-            Object(NonMatching, "core/eggTaskThread.cpp"),
+            Object(Matching,    "core/eggTaskThread.cpp", extra_cflags=["-O4,s"]),
             Object(Matching,    "core/eggThread.cpp", extra_cflags=["-O4,s"]),
             Object(NonMatching, "core/eggUnitHeap.cpp"),
 

--- a/configure.py
+++ b/configure.py
@@ -1909,7 +1909,7 @@ config.libs = [
             Object(NonMatching, "core/eggGraphicsFifo.cpp"),
             Object(NonMatching, "core/eggHeap.cpp"),
             Object(NonMatching, "core/eggTaskThread.cpp"),
-            Object(NonMatching, "core/eggThread.cpp"),
+            Object(Matching,    "core/eggThread.cpp", extra_cflags=["-O4,s"]),
             Object(NonMatching, "core/eggUnitHeap.cpp"),
 
             Object(NonMatching, "prim/eggAssert.cpp"),

--- a/libs/EGG/include/egg/core/eggHeap.h
+++ b/libs/EGG/include/egg/core/eggHeap.h
@@ -53,6 +53,11 @@ namespace EGG {
         }
         static Heap* unkInline2(int id = 0) { return (Heap*)OSGetThreadSpecific(id); }
 
+        static void* alloc(u32 size, int align, Heap* heap);
+        static void free(void* buffer, Heap* heap);
+
+        static Heap* sCurrentHeap;
+
         void* getStartAddress() { return this; }
         void* getEndAddress() { return MEMGetHeapEndAddress(mHeapHandle); }
 

--- a/libs/EGG/include/egg/core/eggTaskThread.h
+++ b/libs/EGG/include/egg/core/eggTaskThread.h
@@ -19,14 +19,9 @@ namespace EGG {
             TFunction mExitFunction;   // 0x10
             TFunction unk_0x14;
 
-            inline TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
+            TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
 
-            inline void clearFunctions() {
-                mFunction = NULL;
-                mEnterFunction = NULL;
-                mExitFunction = NULL;
-                unk_0x14 = NULL;
-            }
+            void clear_functions();
         } TJob;
 
         TaskThread();
@@ -42,6 +37,9 @@ namespace EGG {
         void setMessageQueue(OSMessageQueue* queue) { mpMsgQueue = queue; }
 
         static OSMessage waitQueueMessage(OSMessageQueue* queue, BOOL* result);
+
+    private:
+        TJob* findBlank();
 
     private:
         TJob* mCurrentJob;  // 0x44

--- a/libs/EGG/include/egg/core/eggTaskThread.h
+++ b/libs/EGG/include/egg/core/eggTaskThread.h
@@ -19,18 +19,23 @@ namespace EGG {
             TFunction mExitFunction;   // 0x10
             TFunction unk_0x14;
 
-            TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
+            TJob();
 
             void clear_functions();
         } TJob;
 
-        TaskThread();
+        TaskThread(int capacity, int priority, u32 stackSize);
         virtual ~TaskThread();
 
-        static TaskThread* create(int msgCount, int, u32 size, Heap* heap);
+        virtual void* run();
 
-        void request(TFunction func, void* work, void*);
-        void requestJam(TFunction func, void* work, void*);
+        virtual void onEnter();
+        virtual void onExit();
+
+        static TaskThread* create(int capacity, int priority, u32 stackSize, Heap* heap);
+
+        bool request(TFunction func, void* work, OSMessage msg);
+        bool requestJam(TFunction func, void* work, OSMessage msg);
 
         OSMessageQueue* getThreadMsgQueue() { return mpMsgQueue; }
 

--- a/libs/EGG/include/egg/core/eggThread.h
+++ b/libs/EGG/include/egg/core/eggThread.h
@@ -11,27 +11,44 @@
 namespace EGG {
     class Thread {
     public:
-        Thread(OSThread* currThread, int);
+        static void initialize();
+        static Thread* findThread(OSThread* pOSThread);
+
+        Thread(u32 stackSize, int capacity, int priority, Heap* pHeap = NULL);
+        Thread(OSThread* currThread, int capacity);
         virtual ~Thread();
 
-        static void initialize();
+        virtual void* run();
+
+        virtual void onEnter();
+        virtual void onExit();
 
         OSMessageQueue* getMessageQueue() { return &mMsgQueue; }
+        OSThread* getOSThread() const { return mpThread; }
 
     private:
-        static nw4r::ut::List smThreadList;
+        void setCommonMesgQueue(int capacity, Heap* pHeap);
 
-        Heap* mpHeap;        // 0x04
-        OSThread* mpThread;  // 0x08
+        static void switchThreadCallback(OSThread* pCurrOSThread, OSThread* pNewOSThread);
+        static void* start(void* pArg);
 
-        OSMessageQueue mMsgQueue;  // 0x0C
-        void* mpMsgArray;          // 0x2C
-        s32 mMsgCount;             // 0x30
+    private:
+        nw4r::ut::Link mLink;  // 0x04
 
-        void* mpStack;   // 0x34
-        u32 mStackSize;  // 0x38
+        Heap* mpHeap;        // 0x0C
+        OSThread* mpThread;  // 0x10
 
-        nw4r::ut::Link mLink;  // 0x3C
+        OSMessageQueue mMsgQueue;  // 0x14
+        void* mpMsgArray;          // 0x34
+        s32 mMsgCount;             // 0x38
+
+        void* mpStack;   // 0x3C
+        u32 mStackSize;  // 0x40
+
+        struct ThreadList : public nw4r::ut::List {
+            u32 _pad;
+        };
+        static ThreadList sThreadList;
     };
 }  // namespace EGG
 

--- a/libs/EGG/include/egg/core/eggThread.h
+++ b/libs/EGG/include/egg/core/eggThread.h
@@ -32,7 +32,7 @@ namespace EGG {
         static void switchThreadCallback(OSThread* pCurrOSThread, OSThread* pNewOSThread);
         static void* start(void* pArg);
 
-    private:
+    protected:
         nw4r::ut::Link mLink;  // 0x04
 
         Heap* mpHeap;        // 0x0C
@@ -44,6 +44,8 @@ namespace EGG {
 
         void* mpStack;   // 0x3C
         u32 mStackSize;  // 0x40
+
+    private:
 
         struct ThreadList : public nw4r::ut::List {
             u32 _pad;

--- a/libs/EGG/src/core/eggTaskThread.cpp
+++ b/libs/EGG/src/core/eggTaskThread.cpp
@@ -1,0 +1,121 @@
+#include <egg/core/eggTaskThread.h>
+
+namespace EGG {
+
+    TaskThread* TaskThread::create(int capacity, int priority, u32 stackSize, Heap* pHeap) {
+        if (pHeap == NULL) {
+            pHeap = Heap::sCurrentHeap;
+        }
+        TaskThread* pThread = new (pHeap, 4) TaskThread(capacity, priority, stackSize);
+        if (pThread == NULL) {
+            return NULL;
+        }
+        pThread->mCurrentJob = NULL;
+        pThread->mJobs = new (pHeap, 4) TJob[capacity];
+        pThread->mJobCount = capacity;
+        if (pThread->mJobs == NULL) {
+            delete pThread;
+            return NULL;
+        }
+        for (int i = 0; i < capacity; i++) {
+            pThread->mJobs[i].mFunction = NULL;
+            pThread->mJobs[i].clear_functions();
+        }
+        return pThread;
+    }
+
+    void TaskThread::TJob::clear_functions() {
+        mFunction = NULL;
+        mEnterFunction = NULL;
+        mExitFunction = NULL;
+        unk_0x14 = NULL;
+    }
+
+    TaskThread::TJob::TJob() : mEnterFunction(NULL), mExitFunction(NULL), unk_0x14(NULL) {}
+
+    bool TaskThread::request(TFunction func, void* work, OSMessage msg) {
+        TJob* job = findBlank();
+        if (job == NULL) {
+            return false;
+        }
+        job->mFunction = func;
+        job->unk_0x04 = work;
+        job->mMsg = msg;
+        bool success = OSSendMessage(getMessageQueue(), job, 0) != 0;
+        if (!success) {
+            job->mFunction = NULL;
+        }
+        return success;
+    }
+
+    bool TaskThread::requestJam(TFunction func, void* work, OSMessage msg) {
+        TJob* job = findBlank();
+        if (job == NULL) {
+            return false;
+        }
+        job->mFunction = func;
+        job->unk_0x04 = work;
+        job->mMsg = msg;
+        bool success = OSJamMessage(getMessageQueue(), job, 0) != 0;
+        if (!success) {
+            job->mFunction = NULL;
+        }
+        return success;
+    }
+
+    TaskThread::~TaskThread() {}
+
+    void TaskThread::onEnter() {
+        if (mCurrentJob != NULL && mCurrentJob->mEnterFunction != NULL) {
+            mCurrentJob->mEnterFunction(mCurrentJob->unk_0x04);
+        }
+    }
+
+    void TaskThread::onExit() {
+        if (mCurrentJob != NULL && mCurrentJob->mExitFunction != NULL) {
+            mCurrentJob->mExitFunction(mCurrentJob->unk_0x04);
+        }
+    }
+
+#pragma dont_inline on
+    void* TaskThread::run() {
+        OSInitFastCast();
+        while (true) {
+            OSMessage msg;
+            OSReceiveMessage(&mMsgQueue, &msg, OS_MESSAGE_BLOCK);
+            TJob* job = (TJob*)msg;
+            mCurrentJob = job;
+            if (mCurrentJob->mFunction != NULL) {
+                mCurrentJob->mFunction(mCurrentJob->unk_0x04);
+                if (mpMsgQueue != NULL && job->mMsg != NULL) {
+                    OSSendMessage(mpMsgQueue, job->mMsg, 0);
+                }
+            }
+            job->mFunction = NULL;
+            if (mCurrentJob != NULL && mCurrentJob->unk_0x14 != NULL) {
+                mCurrentJob->unk_0x14(mCurrentJob->unk_0x04);
+            }
+            mCurrentJob = NULL;
+            job->clear_functions();
+        }
+    }
+#pragma dont_inline off
+
+    TaskThread::TaskThread(int capacity, int priority, u32 stackSize)
+        : Thread(stackSize, capacity, priority, NULL), mpMsgQueue(NULL) {
+        OSResumeThread(getOSThread());
+    }
+
+    OSMessage TaskThread::waitQueueMessage(OSMessageQueue* queue, BOOL* result) {
+        OSMessage msg = NULL;
+        BOOL success = FALSE;
+        if (queue != NULL) {
+            success = OSReceiveMessage(queue, &msg, 0);
+        }
+        if (result != NULL) {
+            *result = success;
+        }
+        return msg;
+    }
+
+}  // namespace EGG

--- a/libs/EGG/src/core/eggThread.cpp
+++ b/libs/EGG/src/core/eggThread.cpp
@@ -1,0 +1,96 @@
+#include <egg/core/eggThread.h>
+
+#include <egg/core/eggTaskThread.h>
+
+namespace EGG {
+
+    Thread::ThreadList Thread::sThreadList;
+
+    TaskThread::TJob* TaskThread::findBlank() {
+        for (int i = 0; i < mJobCount; i++) {
+            if (mJobs[i].mFunction == NULL) {
+                mJobs[i].clear_functions();
+                return &mJobs[i];
+            }
+        }
+        return NULL;
+    }
+
+    void Thread::switchThreadCallback(OSThread* pCurrOSThread, OSThread* pNewOSThread) {
+        Thread* pCurrThread = findThread(pCurrOSThread);
+        Thread* pNewThread = findThread(pNewOSThread);
+        if (pCurrThread != NULL) {
+            pCurrThread->onExit();
+        }
+        if (pNewThread != NULL) {
+            pNewThread->onEnter();
+        }
+    }
+
+    void Thread::onEnter() {}
+    void Thread::onExit() {}
+
+    Thread::Thread(u32 stackSize, int capacity, int priority, Heap* pHeap) {
+        if (pHeap == NULL) {
+            pHeap = Heap::sCurrentHeap;
+        }
+        mpHeap = pHeap;
+        mStackSize = stackSize & ~0x1F;
+        mpStack = Heap::alloc(mStackSize, 0x20, mpHeap);
+        mpThread = (OSThread*)Heap::alloc(sizeof(OSThread), 0x20, mpHeap);
+        OSCreateThread(mpThread, Thread::start, this, (u8*)mpStack + mStackSize, mStackSize, priority, OS_THREAD_ATTR_DETACH);
+        setCommonMesgQueue(capacity, mpHeap);
+    }
+
+    Thread::Thread(OSThread* currThread, int capacity) {
+        mpHeap = NULL;
+        mpThread = currThread;
+        mStackSize = (u32)((u8*)currThread->stackEnd - (u8*)currThread->stackBase);
+        mpStack = currThread->stackBase;
+        setCommonMesgQueue(capacity, Heap::sCurrentHeap);
+    }
+
+    Thread::~Thread() {
+        nw4r::ut::List_Remove(&sThreadList, this);
+        if (mpHeap != NULL) {
+            if (!OSIsThreadTerminated(mpThread)) {
+                OSDetachThread(mpThread);
+                OSCancelThread(mpThread);
+            }
+            Heap::free(mpStack, mpHeap);
+            Heap::free(mpThread, mpHeap);
+        }
+        Heap::free(mpMsgArray, NULL);
+    }
+
+    Thread* Thread::findThread(OSThread* pOSThread) {
+        Thread* it = NULL;
+        while ((it = (Thread*)nw4r::ut::List_GetNext(&sThreadList, it)) != NULL) {
+            if (it->mpThread == pOSThread) {
+                return it;
+            }
+        }
+        return NULL;
+    }
+
+    void Thread::initialize() {
+        nw4r::ut::List_Init(&sThreadList, offsetof(Thread, mLink));
+        OSSetSwitchThreadCallback(Thread::switchThreadCallback);
+    }
+
+    void Thread::setCommonMesgQueue(int capacity, Heap* pHeap) {
+        mMsgCount = capacity;
+        mpMsgArray = Heap::alloc(capacity * sizeof(OSMessage), 4, pHeap);
+        OSInitMessageQueue(&mMsgQueue, (OSMessage*)mpMsgArray, mMsgCount);
+        nw4r::ut::List_Append(&sThreadList, this);
+    }
+
+    void* Thread::start(void* pArg) {
+        return ((Thread*)pArg)->run();
+    }
+
+    void* Thread::run() {
+        return NULL;
+    }
+
+}  // namespace EGG

--- a/libs/RVL_SDK/include/revolution/os/OSFastCast.h
+++ b/libs/RVL_SDK/include/revolution/os/OSFastCast.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-static void OSInitFastCast() {
+inline void OSInitFastCast() {
     // clang-format off
 #ifdef __MWERKS__
     asm {

--- a/src/system/iplErrorHandler.cpp
+++ b/src/system/iplErrorHandler.cpp
@@ -53,7 +53,7 @@ namespace ipl {
         }
 
         curThread = OSGetCurrentThread();
-        if (curThread == System::getMainThread()->getMessageQueue()->queueSend.tail) {
+        if (curThread == System::getMainThread()->getOSThread()) {
             check();
         } else {
             OSCancelThread(curThread);


### PR DESCRIPTION
## Summary
- `libs/EGG/src/core/eggThread.cpp` — 12/12 functions matching, .text + .data + .bss SHA1 match.
- `libs/EGG/src/core/eggTaskThread.cpp` — 12/12 functions matching, .text + .data SHA1 match.
- Both compiled with `extra_cflags=["-O4,s"]` (space optimization triggers `_savegpr_N`/`_restgpr_N` helper emission needed for matching).

## Notes
- `EGG::Thread` layout: `mLink` is at offset `0x04` (not `0x3C` as the old header claimed). Members shifted accordingly. Static `sThreadList` is 16 bytes (a `nw4r::ut::List` plus a 4-byte trailing pad), modeled as a private `ThreadList : public nw4r::ut::List` wrapper struct so the rest of the codebase keeps the canonical 12-byte `nw4r::ut::List`.
- `EGG::TaskThread::TJob::TJob()` is non-inline — the original emits it between `clear_functions` and `request`, so source order matters.
- `EGG::TaskThread::run()` wrapped in `#pragma dont_inline on/off` to force a real `bl OSInitFastCast` call (target emits `OSInitFastCast` as a weak global at `.text:0x3AC` rather than inlining it).
- `OSInitFastCast` changed from `static` to `inline` in `OSFastCast.h` so mwcc emits it as a weak external in TUs that take its address (matches target's emission).
- `EGG::TaskThread::findBlank()` is defined in `eggThread.cpp` (not `eggTaskThread.cpp`) — that's where the original linker map places it.

## Test plan
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] objdiff report: `eggThread` 100% (12/12), `eggTaskThread` 100% (12/12).
- [x] No regressions in other "complete" units (the only two non-100% complete units, `OS` and `targsupp`, were already broken before this branch).