### PR TITLE
Match ChannelScriptManager::isValidAddr()

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -617,7 +617,7 @@ config.libs = [
             Object(Equivalent,  "system/iplSystem.cpp"),
             Object(NonMatching, "system/iplController.cpp"),
             Object(Equivalent,  "system/iplChannelManager.cpp"),
-            Object(Equivalent,  "system/iplChannelScriptManager.cpp"),
+            Object(Matching,    "system/iplChannelScriptManager.cpp"),
             Object(Matching,    "system/iplNand.cpp"),
             Object(NonMatching, "system/iplNandShared.cpp"),
             Object(Matching,    "system/iplNandMeta.cpp"),

--- a/src/system/iplChannelScriptManager.cpp
+++ b/src/system/iplChannelScriptManager.cpp
@@ -151,8 +151,10 @@ namespace ipl {
         BOOL ChannelScriptManager::isValidAddr(void* addr) {
             EGG::Heap* heap1 = mpHeap;
             EGG::Heap* heap2 = mCSData.heap;
+            void* end1 = heap1->getEndAddress();
+            void* end2 = heap2->getEndAddress();
 
-            return heap1->isHeapPointer(addr) || heap2->isHeapPointer(addr);
+            return ((u8*)heap1 <= addr && addr < end1) || ((u8*)heap2 <= addr && addr < end2);
         }
 
         void ChannelScriptManager::calcCSThread() {


### PR DESCRIPTION
## Summary
- `ipl::channel::ChannelScriptManager::isValidAddr()` upgraded from Equivalent → Matching.
- File `src/system/iplChannelScriptManager.cpp` now 100% (10/10 functions).

## Notes
The original `isHeapPointer()` calls had the compiler scheduling each heap's `getEndAddress()` load lazily (only after the start-address compare succeeded). The target compiler eagerly loads both heaps' end addresses upfront. Hoisting `end1` / `end2` into local variables produces the same instruction scheduling and matches byte-for-byte.

## Test plan
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] objdiff: `iplChannelScriptManager` 100% (10/10 functions).
- [x] No regressions in any other complete unit.