### PR TITLE
MESG_BOARD_OPT_OUT: split per-version (Board::focus / stt_focus 100%)

### DIFF
--- a/include/system/MESGEntries.h
+++ b/include/system/MESGEntries.h
@@ -76,8 +76,8 @@
 #define MESG_BOARD_CHJUMP_CONFIRM       88
 #define MESG_BOARD_CHJUMP_NO_OPERA      89
 #define MESG_BOARD_CHJUMP_LAUNCH_ERROR  90
-#define MESG_BOARD_OPT_OUT              92
 #ifndef VERSION_43E
+#define MESG_BOARD_OPT_OUT              101
 #define MESG_BOARD_OPT_OUT_SELECT       102
 #define MESG_BOARD_OPT_OUT_ONE          103
 #define MESG_BOARD_OPT_OUT_ALL          104
@@ -87,6 +87,7 @@
 #define MESG_BOARD_OPT_OUT_DONE_ALL     108
 #define MESG_BOARD_NWC24_DELETE_FAIL    109
 #else
+#define MESG_BOARD_OPT_OUT              92
 #define MESG_BOARD_OPT_OUT_SELECT       93
 #define MESG_BOARD_OPT_OUT_ONE          94
 #define MESG_BOARD_OPT_OUT_ALL          95


### PR DESCRIPTION
## Summary
- `MESG_BOARD_OPT_OUT` was always `92` regardless of region, but the rest of the OPT_OUT constants differed between 43E and non-43E. Bumped `MESG_BOARD_OPT_OUT` to `101` on non-43E (consistent with how the other OPT_OUT IDs in the same block jump to 102+ on non-43E).
- This brings `ipl::scene::Board::focus()` and `ipl::scene::Board::stt_focus()` to 100% match in 43U.

## Notes
The diff was a single instruction off in `Board::focus()`: the target uses `li r4, 0x65` (=101) for `setText(MESG_BOARD_OPT_OUT)` but our build emitted `li r4, 0x5c` (=92). Looking at the surrounding `#ifndef VERSION_43E` block, `MESG_BOARD_OPT_OUT_SELECT` is `102`, `..._ONE` is `103`, etc., so `OPT_OUT` slotting in at `101` makes the block contiguous (101–109). On 43E the same constants are 92–100, again contiguous.

## Test plan
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] objdiff: `Board::focus()` and `Board::stt_focus()` 100%.
- [x] No regressions in any complete unit (only pre-existing `OS` and `targsupp` are below 100%).