### PR TITLE
VmIntToFloat / VmIsNan: static + correct u64 sign-bit check

### DIFF
--- a/src/channelScript/CHANSVm.c
+++ b/src/channelScript/CHANSVm.c
@@ -1053,10 +1053,10 @@ CHANSVmErr VmMul(CHANSVm* vm, int type, CHANSVmObjHdr* ret, CHANSVmObjHdr* left,
     return err;
 }
 
-vmFloat VmIntToFloat(vmU64 integer) {  // should be vmInteger (s64)????
+static vmFloat VmIntToFloat(vmU64 integer) {
     vmFloat result;
 
-    if ((integer & 0x80000000) != 0) {
+    if ((integer & 0x8000000000000000ULL) != 0) {
         result = -(vmFloat)(~integer + 1);
     } else {
         result = (vmFloat)integer;
@@ -1365,7 +1365,7 @@ CHANSVmErr VmCmpGeq(CHANSVm* vm, int type, CHANSVmObjHdr* ret, CHANSVmObjHdr* le
     return VmCmpLeq(vm, type, ret, right, left);
 }
 
-vmBoolInt VmIsNan(vmFloat param_1) {
+static vmBoolInt VmIsNan(vmFloat param_1) {
     return isnan(param_1) || param_1 == (0.0f / 0.0f);
 }
 


### PR DESCRIPTION
## Summary
- `VmIntToFloat()` and `VmIsNan()` upgraded to 100% match.

## Notes
**`VmIntToFloat`:** the function takes a `vmU64` (64-bit) and the original code masked with `0x80000000` (a 32-bit constant), which only checks bit 31 of the *low* half — not the sign bit. The target asm clearly tests the high half register (`r3`) instead of the low half (`r4`), so the original source was masking with `0x8000000000000000ULL` (the actual u64 sign bit). Fixed.

Also, target marks both functions as `local` (static). Adding `static` matches the linkage.

## Test plan
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] objdiff: `VmIntToFloat` and `VmIsNan` both 100%.
- [x] No regressions in any complete unit.