### PR TITLE
DVDSetAutoFatalMessaging(): branchless via & -(x!=0)

### DIFF
--- a/src/BS2/BS2Fatal.c
+++ b/src/BS2/BS2Fatal.c
@@ -374,11 +374,13 @@ void __DVDShowFatalMessage() {
 int DVDSetAutoFatalMessaging(BOOL enable) {
     BOOL enabled;
     BOOL prev;
+    void (*oldFunc)();
 
     enabled = OSDisableInterrupts();
 
-    prev = FatalFunc ? TRUE : FALSE;
-    FatalFunc = enable ? __DVDShowFatalMessage : NULL;
+    oldFunc = FatalFunc;
+    prev = oldFunc ? TRUE : FALSE;
+    FatalFunc = (void (*)())((u32)__DVDShowFatalMessage & -(enable != 0));
 
     OSRestoreInterrupts(enabled);
     return prev;


### PR DESCRIPTION
## Summary
- `DVDSetAutoFatalMessaging()` now matches 100%. The file's data sections still differ slightly so it stays `Equivalent` rather than `Matching`, but the function-level diff is fully resolved (10/10 functions match).

## Notes
The target compiles `enable ? __DVDShowFatalMessage : NULL` branchless via `subfic`/`subfe`/`and`. mwcc emits a branch from the natural ternary on this version. The arithmetic equivalent `(u32)__DVDShowFatalMessage & -(enable != 0)` produces the exact same byte-pattern as the target — same as the standard "broadcast a condition into all bits" idiom that mwcc itself uses internally for similar conditions.

The `oldFunc` local is added because the target reads `FatalFunc` once into a temp before computing both `prev` and the new `FatalFunc`, then writes back. mwcc only schedules the loads/stores in this interleaved order if the source matches that shape.

## Test plan
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] objdiff: `BS2Fatal` 100% (10/10 functions); was 96.92% before.
- [x] No regressions in any complete unit.