### PR TITLE
iplUrlProcessor::get_selected_col(): fix infinite-loop bug + 100%

### DIFF
--- a/src/scene/board/iplUrlProcessor.cpp
+++ b/src/scene/board/iplUrlProcessor.cpp
@@ -195,7 +195,7 @@ namespace ipl {
             url_collision* got = NULL;
             url_collision* url_col = NULL;
 
-            while (got = (url_collision*)nw4r::ut::List_GetNext(&mUrlCollisions, url_col), got != NULL) {
+            while (got = (url_collision*)nw4r::ut::List_GetNext(&mUrlCollisions, got), got != NULL) {
                 if (got->unk_0x00 == unk_0x4C) {
                     url_col = got;
                     break;


### PR DESCRIPTION
## Summary

`get_selected_col()` was iterating `nw4r::ut::List_GetNext(&list, url_col)` where `url_col` only becomes non-NULL on a match (right before `break`). On any non-matching list, it would always re-read element 0 and loop forever. The original passes `got` (the value just returned) as the previous element. With this fix, the function reaches 100%.

## Test plan
- [x] objdiff: `get_selected_col()` 88.33% → 100%.
- [x] `ninja` produces `build/43U/main.dol` whose SHA1 matches `26116613f624061ba99c8d1a299aaa6efa85670d`.
- [x] No regressions in any other unit.