### PR TITLE
iplNCDSetting: 11 function matches + missing implementations

### DIFF
--- a/include/scene/setting/iplNCDSetting.h
+++ b/include/scene/setting/iplNCDSetting.h
@@ -42,7 +42,7 @@ namespace ipl {
             static void setWired();
             static void setWireless(unsigned char);
             static void changeConnectType(unsigned char);
-            static void setSSID(const char*);
+            static void setSSID(unsigned char*);
             static void setPrivacyMode(unsigned short);
             static void setWDPrivacyMode(unsigned short);
             static void setPrivacy(unsigned char*, int);

--- a/include/scene/setting/iplNCDSetting.h
+++ b/include/scene/setting/iplNCDSetting.h
@@ -66,7 +66,7 @@ namespace ipl {
             static u16 getNCDPrivacyMode();
             static u8* getPrivacy();
             static u16 getPrivacyLen();
-            static int getIP();
+            static u8* getIP();
             static u32 getMacNum();
             static u8* getMacAddr();
             static int makeMacAddr();

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -476,11 +476,11 @@ namespace ipl {
             }
 
             if (param_2 >= '0' && param_2 <= '9') {
-                *param_3 = *param_3 + ((param_2 - '0') << 24);
+                *param_3 = *param_3 + (u8)(param_2 - '0');
             } else if (param_2 >= 'A' && param_2 <= 'F') {
-                *param_3 = *param_3 + ((param_2 - 'A' + 10) << 24);
+                *param_3 = *param_3 + (u8)(param_2 - 'A' + 10);
             } else if (param_2 >= 'a' && param_2 <= 'f') {
-                *param_3 = *param_3 + ((param_2 - 'a' + 10) << 24);
+                *param_3 = *param_3 + (u8)(param_2 - 'a' + 10);
             } else {
                 ret = false;
             }

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -321,9 +321,9 @@ namespace ipl {
         }
 
         void NCDSetting::setPrivacy(unsigned char* newKey, int len) {
-            u16 mode = mConfig.profiles[mID].netif.wireless.config.manual.privacy.wep40.option;
+            u8 mode = mConfig.profiles[mID].netif.wireless.config.manual.privacy.wep40.reserved[0];
             memset(&mConfig.profiles[mID].netif.wireless.config.manual.privacy.wep104, 0, 0x44);
-            mConfig.profiles[mID].netif.wireless.config.manual.privacy.wep40.option = mode;
+            mConfig.profiles[mID].netif.wireless.config.manual.privacy.wep40.reserved[0] = mode;
             if (len == 0) {
                 mConfig.profiles[mID].netif.wireless.config.manual.privacy.mode = 0;
             } else {

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -726,35 +726,32 @@ namespace ipl {
         }
 
         int NCDSetting::makeMacAddr() {
-            u8 macAddress[6];
-            long long uVar2;
-            char* mac;
-            u32 local_2d;
+            u8 macAddress[7];
+            char mac[32];
 
             NCDErr err = NETGetWirelessMacAddress(macAddress);
-            if (err != -4) {
-                if (err < -4) {
-                    if (err == -8) {
-                        goto fail;
-                    }
-                } else if (err == 0) {
+            switch (err) {
+                case 0:
                     sprintf(mac, "%02x-%02x-%02x-%02x-%02x-%02x", macAddress[0], macAddress[1], macAddress[2], macAddress[3], macAddress[4],
                             macAddress[5]);
-                    OSReport("MAC: %s\n", &mac);
-
-                    ipl::utility::CharacterCode::ANSIToUTF8((char*)mMac, (u8*)&mac);
-
-                    memset(&mac, 0, 18);
-                    memcpy(&mac, &macAddress, 6);
-                    uVar2 = *mac % 100000000;
-                    // uVar2 = __mod2u(local_31, local_2d, 0, 100000000);
-                    mMacNum = (int)uVar2;
-                    OSReport("%lld %d\n", mMacNum, mac, local_2d, mMacNum);
-                }
-                OSPanic("iplNCDSetting.cpp", 0x43b, "Unrecoverable Error!!");
+                    OSReport("MAC: %s\n", mac);
+                    ipl::utility::CharacterCode::ANSIToUTF8((char*)mMac, (u8*)mac);
+                    memset(mac, 0, 18);
+                    memcpy(&mac[2], macAddress, 6);
+                    {
+                        u64 num = *(u64*)mac;
+                        mMacNum = (int)(num % 100000000);
+                        OSReport("%lld %d\n", num, mMacNum);
+                    }
+                    break;
+                case -4:
+                case -8:
+                    OSPanic("iplNCDSetting.cpp", 0x436, "try again!!");
+                    break;
+                default:
+                    OSPanic("iplNCDSetting.cpp", 0x43b, "Unrecoverable Error!!");
+                    break;
             }
-        fail:
-            OSPanic("iplNCDSetting.cpp", 0x436, "try again!!");
         }
     }  // namespace ncd
 }  // namespace ipl

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -222,8 +222,9 @@ namespace ipl {
                 if (param_1[0] == '.') {
                     ret = 0;
                 } else {
+                    char c;
                     for (int i = 0; i < len; i++) {
-                        char c = param_1[i];
+                        c = param_1[i];
                         if (((c < '0' || '9' < c) && (c < 'a' || 'z' < c)) && ((((c < 'A' || 'Z' < c) && c != '-') && (c != '.' && c != '_')))) {
                             return 0;
                         }

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -459,7 +459,7 @@ namespace ipl {
 
         unsigned int NCDSetting::checkChangeEnable() {
             u8 configMethod = mConfig.profiles[mID].netif.wireless.configMethod;
-            return (1 - ((u8)configMethod + 0xff & 0xff)) >> (u8)0x1f;
+            return (u32)(1 - ((u8)configMethod + 0xff & 0xff)) >> (u8)0x1f;
         }
 
         undefined4 NCDSetting::convert16toASCII(char param_1, char param_2, unsigned char* param_3) {

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -15,6 +15,12 @@
 
 namespace ipl {
     namespace ncd {
+        NCDConfig NCDSetting::mConfig;
+        u16 NCDSetting::mID;
+        u8 NCDSetting::mMac[32];
+        u32 NCDSetting::mMacNum;
+        NCDConfig NCDSetting::mSaveConfig;
+
         int NCDSetting::init() {
             memset(&mConfig, 0, sizeof(mConfig));
             int status = NCDReadConfig(&mConfig);

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -256,8 +256,10 @@ namespace ipl {
         }
 
         void NCDSetting::adjustNCDData_() {
-            int i = 0;
-            int theOne = -1;
+            int i;
+            int theOne;
+            theOne = -1;
+            i = 0;
             for (; i < 3; i++) {
                 if ((mConfig.profiles[i].flags & 0x80) != 0) {
                     adjustSelectMedia_(i);

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -57,9 +57,17 @@ namespace ipl {
             mConfig.profiles[mID].flags &= 0xfe;
         }
 
-        void NCDSetting::setSSID(const char* newSSID) {
+        void NCDSetting::setSSID(unsigned char* newSSID) {
             memcpy(mConfig.profiles[mID].netif.wireless.config.manual.ssid, newSSID, 32);
-            mConfig.profiles[mID].netif.wireless.config.manual.ssidLength = strlen(newSSID);
+            mConfig.profiles[mID].netif.wireless.config.manual.ssidLength = strlen((char*)newSSID);
+        }
+
+        void NCDSetting::setAOSSParams(const NCDAossConfig& aossConfig) {
+            mConfig.profiles[mID].netif.wireless.config.aoss = aossConfig;
+        }
+
+        void NCDSetting::setRakuParams(const NCDApConfig& rakuConfig) {
+            mConfig.profiles[mID].netif.wireless.config.rakuraku = rakuConfig;
         }
 
         void NCDSetting::setPrivacyMode(u16 newMode) {

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -579,8 +579,8 @@ namespace ipl {
             return 3;
         }
 
-        int NCDSetting::getIP() {
-            return *(int*)mConfig.profiles[mID].ip.addr;
+        u8* NCDSetting::getIP() {
+            return mConfig.profiles[mID].ip.addr;
         }
 
         u32 NCDSetting::getMacNum() {

--- a/src/scene/setting/iplNCDSetting.cpp
+++ b/src/scene/setting/iplNCDSetting.cpp
@@ -284,17 +284,12 @@ namespace ipl {
             u8 asciiKey[14];
             memset(asciiKey, 0, sizeof(asciiKey));
 
-            if (keyLen == 0)
-                return 0;
-
-            int privacyMode = getPrivacyMode();
-
-            if ((privacyMode & 0xFFFF) > 1) {
-                if (keyLen < 8 || keyLen >= 64) {
-                    return keyLen;
-                }
-
-                if (keyLen == 64) {
+            if (keyLen == 0) {
+                ret = 0;
+            } else if ((u16)getPrivacyMode() > 1) {
+                if (keyLen >= 8 && keyLen < 64) {
+                    ret = keyLen;
+                } else if (keyLen == 64) {
                     for (int i = 0; i < 64; i++) {
                         char c = key[i];
                         if ((((c < '0') || ('9' < c)) && ((c < 'A' || ('F' < c)))) && ((c < 'a' || ('f' < c)))) {
@@ -303,29 +298,26 @@ namespace ipl {
                     }
                     ret = keyLen;
                 }
-
-                return ret;
-            }
-
-            if (keyLen == 10 || keyLen == 26) {
+            } else if (keyLen == 10 || keyLen == 26) {
+                int i = 0;
                 int outLen = 0;
-                for (int i = 0; i < keyLen; i += 2) {
+                while (i < keyLen) {
                     if (convert16toASCII(key[i], key[i + 1], &asciiKey[outLen]) == 0)
                         return -1;
+                    i += 2;
                     outLen++;
                 }
-
-                memcpy(key, asciiKey, keyLen);
-                mConfig.profiles[mID].netif.wireless.config.aoss.wep40.key[1][1] = 1;
-                return keyLen / 2;
-            }
-
-            if (keyLen == 5 || keyLen == 13) {
+                if (i == 10 || i == 26) {
+                    memcpy(key, asciiKey, i);
+                    mConfig.profiles[mID].netif.wireless.config.aoss.wep40.key[1][1] = 1;
+                    return i / 2;
+                }
+                return -1;
+            } else if (keyLen == 5 || keyLen == 13) {
                 mConfig.profiles[mID].netif.wireless.config.aoss.wep40.key[1][1] = 0;
-                return keyLen;
+                ret = keyLen;
             }
-
-            return -1;
+            return ret;
         }
 
         void NCDSetting::setPrivacy(unsigned char* newKey, int len) {


### PR DESCRIPTION
## Summary

Cleans up `iplNCDSetting.cpp`. Brings 8 functions to 100% match, implements 3 functions that were missing or had wrong signatures, defines static members so the file is link-self-sufficient, and partially improves 2 others. Overall match goes 92.10% → 99.85% (60/62 functions matching).

File stays `NonMatching` in `configure.py` because two functions remain just below 100% (`setPrivacy` 99.89% — regswap r24/r25; `setRakuParams` 91.9% — target uses byte-copy inlining vs current's halfword copy).

## Real bug fixes (not just regswaps)

- **`convert16toASCII()`**: low-nibble path used `<< 24`, which after the u8 store left the value zeroed — the second hex digit was effectively never added. Replaced with `(u8)(...)` to match the original's `& 0xFF`.
- **`makeMacAddr()`**: used an uninitialized `char* mac` pointer for `sprintf`, `OSReport`, `memset`, `memcpy`, and the `*mac % 100000000` modulo. Rewrote as a `char[32]` buffer with a `switch` on `err` matching the original's control flow.
- **`setSSID()`** had a `const char*` signature but the original mangling is `PUc` (= `unsigned char*`). Header and body updated; one strlen cast added.

## Other matches

- **`checkWEPKey()` 90.03% → 100%**: restructured the if/elseif chain so all returns funnel through `ret`; added the redundant `i == 10 || i == 26` inner check the original generates.
- **`getIP()` 91.43% → 100%**: return type was `int` (forcing a dereference); the target returns the `u8*` to `ip.addr`.
- **`checkChangeEnable()` 94.55% → 100%**: cast to `u32` so the right-shift uses `srwi` (logical) not `srawi` (arithmetic).
- **`checkProxy()` 99.10% → 100%**: declaring `c` outside the loop flips r4/r5 to match the original allocation.
- **`adjustNCDData_()` 99.69% → 100%**: split declarations from initializations so the scheduler emits `li r28, -1` (`theOne`) before the other inits.
- **`setAOSSParams()`**: implemented via whole-struct assignment.
- **`setRakuParams()`**: implemented via whole-struct assignment; reaches 91.9% (target inlines as bytes, current as halfwords).

## Static members

`NCDSetting::mConfig`, `mID`, `mMac`, `mMacNum`, `mSaveConfig` were declared in the header but never defined; relied on the asm version having the symbols. Added definitions so the file is self-contained.

## Test plan

- [x] objdiff: `iplNCDSetting.cpp` 92.10% → 99.85% (60/62 functions at 100%).
- [x] `ninja` produces \`build/43U/main.dol\` whose SHA1 matches \`26116613f624061ba99c8d1a299aaa6efa85670d\` (file is still \`NonMatching\` so the link uses the asm version; promotion to \`Matching\` requires the last two regswap functions).
- [x] No regressions in any other unit.